### PR TITLE
Don't send nil publications across the channel; if they're pulled fro…

### DIFF
--- a/lib/oplog/tail.go
+++ b/lib/oplog/tail.go
@@ -151,7 +151,11 @@ func (tailer *Tailer) tailOnce(out chan<- *redispub.Publication, stop <-chan boo
 			}
 
 			for _, pub := range pubs {
-				out <- pub
+				if pub != nil {
+					out <- pub
+				} else {
+					log.Log.Error("Nil Redis publication")
+				}
 			}
 		}
 

--- a/lib/redispub/publisher.go
+++ b/lib/redispub/publisher.go
@@ -96,8 +96,11 @@ func PublishStream(client redis.UniversalClient, in <-chan *Publication, opts *P
 }
 
 func publishSingleMessageWithRetries(p *Publication, maxRetries int, sleepTime time.Duration, publishFn func(p *Publication) error) error {
-	retries := 0
+	if p == nil {
+		return errors.New("Nil Redis publication")
+	}
 
+	retries := 0
 	for retries < maxRetries {
 		err := publishFn(p)
 
@@ -134,9 +137,9 @@ func publishSingleMessage(p *Publication, client redis.UniversalClient, prefix s
 			formatKey(p, prefix),
 		},
 		dedupeExpirationSeconds, // ARGV[1], expiration time
-		p.Msg,                   // ARGV[2], message
-		p.CollectionChannel,     // ARGV[3], channel #1
-		p.SpecificChannel,       // ARGV[4], channel #2
+		p.Msg,               // ARGV[2], message
+		p.CollectionChannel, // ARGV[3], channel #1
+		p.SpecificChannel,   // ARGV[4], channel #2
 	).Result()
 
 	return err

--- a/lib/redispub/publisher_test.go
+++ b/lib/redispub/publisher_test.go
@@ -174,3 +174,14 @@ func TestPeriodicallyUpdateTimestamp(t *testing.T) {
 	close(timestampC)
 	waitGroup.Wait()
 }
+
+func TestNilPublicationMessage(t *testing.T) {
+	err := publishSingleMessageWithRetries(nil, 5, 1*time.Second, func(p *Publication) error {
+		t.Error("Should not have been called")
+		return nil
+	})
+
+	if err == nil {
+		t.Error("Exepcted error")
+	}
+}


### PR DESCRIPTION
…m the channel, don't process them

Evidently nil `redis.Publication` pointers were being read from the redis channel; have an environment where the below stack trace appears relatively frequently:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x38 pc=0x890058]

goroutine 229 [running]:
github.com/tulip/oplogtoredis/lib/redispub.formatKey(0x0, 0xc00002a9aa, 0xe, 0xc00030a790, 0x1)
	/oplogtoredis/lib/redispub/publisher.go:146 +0x38
github.com/tulip/oplogtoredis/lib/redispub.publishSingleMessage(0x0, 0xaa0dc0, 0xc0001a5ea0, 0xc00002a9aa, 0xe, 0x78, 0x0, 0x1)
	/oplogtoredis/lib/redispub/publisher.go:134 +0x5a
github.com/tulip/oplogtoredis/lib/redispub.PublishStream.func1(0x0, 0x0, 0x0)
	/oplogtoredis/lib/redispub/publisher.go:67 +0x5c
github.com/tulip/oplogtoredis/lib/redispub.publishSingleMessageWithRetries(0x0, 0x1e, 0x3b9aca00, 0xc000528bd0, 0x1, 0x0)
	/oplogtoredis/lib/redispub/publisher.go:102 +0x189
github.com/tulip/oplogtoredis/lib/redispub.PublishStream(0xaa0dc0, 0xc0001a5ea0, 0xc000072c00, 0xc00023f3a0, 0xc0003e2d80)
	/oplogtoredis/lib/redispub/publisher.go:80 +0x316
main.main.func3(0xaa0dc0, 0xc0001a5ea0, 0xc000072c00, 0xc0003e2d80, 0xc0003ae320)
	/oplogtoredis/main.go:83 +0xdf
created by main.main
	/oplogtoredis/main.go:82 +0x34a
```