### PR TITLE
use rediss:// to specify to use TLS instead of env variable config

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,12 +53,6 @@ You can build oplogtoredis from source with `go build .`, which produces a
 statically-linked binary you can run. Alternatively, you can use [the public
 docker image](https://hub.docker.com/r/tulip/oplogtoredis/tags/)
 
-### TLS
-
-To connect to a instance over TLS be sure to specify the url with protocol
-`rediss://`, otherwise use `redis://`
-
-
 ### Environment Variables
 
 You must set the following environment variables:
@@ -68,6 +62,8 @@ You must set the following environment variables:
   `MONGO_OPLOG_URL` you give to your Meteor server.
 
 - `OTR_REDIS_URL`: Required: Redis URL to publish updates to.
+  To connect to a instance over TLS be sure to specify
+  OTR_REDIS_URL url with protocol `rediss://`, otherwise use `redis://`
 
 
 You may also set the following environment variables to configure the

--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ You must set the following environment variables:
   `MONGO_OPLOG_URL` you give to your Meteor server.
 
 - `OTR_REDIS_URL`: Required: Redis URL to publish updates to.
-
-- `OTR_REDIS_TLS`: Optional: Defaults to `false`. Set to `true` in order connect via TLS to redis.
+	To connect to a instance over TLS be sure to specify the url with protocol
+	`rediss://`, otherwise use `redis://`
 
 You may also set the following environment variables to configure the
 level of logging:
@@ -75,6 +75,7 @@ There are a number of other environment variables you can set to tune
 various performance and reliability settings. See the
 [config package docs](https://godoc.org/github.com/tulip/oplogtoredis/lib/config)
 for more details.
+
 
 ## Running oplogtoredis in production
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,14 @@ You can build oplogtoredis from source with `go build .`, which produces a
 statically-linked binary you can run. Alternatively, you can use [the public
 docker image](https://hub.docker.com/r/tulip/oplogtoredis/tags/)
 
+### TLS
+
+To connect to a instance over TLS be sure to specify the url with protocol
+`rediss://`, otherwise use `redis://`
+
+
+### Environment Variables
+
 You must set the following environment variables:
 
 - `OTR_MONGO_URL`: Required. Mongo URL to read the oplog from. This should
@@ -60,8 +68,7 @@ You must set the following environment variables:
   `MONGO_OPLOG_URL` you give to your Meteor server.
 
 - `OTR_REDIS_URL`: Required: Redis URL to publish updates to.
-	To connect to a instance over TLS be sure to specify the url with protocol
-	`rediss://`, otherwise use `redis://`
+
 
 You may also set the following environment variables to configure the
 level of logging:

--- a/blackbox-tests/docker-compose.yml
+++ b/blackbox-tests/docker-compose.yml
@@ -19,8 +19,7 @@ services:
         oplogtoredis
     environment:
       - OTR_MONGO_URL=mongodb://mongo/dev
-      - OTR_REDIS_URL=redis://redis_tls:6380
-      - OTR_REDIS_TLS=true
+      - OTR_REDIS_URL=rediss://redis_tls:6380
     ports:
       - 9000:9000
     depends_on:

--- a/lib/config/main.go
+++ b/lib/config/main.go
@@ -12,7 +12,6 @@ import (
 type oplogtoredisConfiguration struct {
 	RedisURL               string        `required:"true" split_words:"true"`
 	MongoURL               string        `required:"true" split_words:"true"`
-	RedisTLS               bool          `default:"false" envconfig:"REDIS_TLS"`
 	HTTPServerAddr         string        `default:"0.0.0.0:9000" envconfig:"HTTP_SERVER_ADDR"`
 	BufferSize             int           `default:"10000" split_words:"true"`
 	TimestampFlushInterval time.Duration `default:"1s" split_words:"true"`
@@ -25,6 +24,8 @@ var globalConfig *oplogtoredisConfiguration
 
 // RedisURL is the Redis URL configuration. It is required, and is set via the
 // environment variable `OTR_REDIS_URL`.
+// To connect to a instance over TLS be sure to specify the url with protocol
+// `rediss://`, otherwise use `redis://`
 func RedisURL() string {
 	return globalConfig.RedisURL
 }
@@ -33,11 +34,6 @@ func RedisURL() string {
 // environment variable `OTR_MONGO_URL`.
 func MongoURL() string {
 	return globalConfig.MongoURL
-}
-
-// RedisTLS determines if the connection to Redis will be made over TLS or not.
-func RedisTLS() bool {
-	return globalConfig.RedisTLS
 }
 
 // HTTPServerAddr the address we bind our HTTP server to. The HTTP server

--- a/lib/config/main_test.go
+++ b/lib/config/main_test.go
@@ -16,7 +16,6 @@ var envTests = map[string]struct {
 		env: map[string]string{
 			"OTR_REDIS_URL":                "redis://something",
 			"OTR_MONGO_URL":                "mongodb://something",
-			"OTR_REDIS_TLS":                "true",
 			"OTR_HTTP_SERVER_ADDR":         "localhost:1234",
 			"OTR_BUFFER_SIZE":              "10",
 			"OTR_TIMESTAMP_FLUSH_INTERVAL": "10m",
@@ -27,7 +26,6 @@ var envTests = map[string]struct {
 		expectedConfig: &oplogtoredisConfiguration{
 			RedisURL:               "redis://something",
 			MongoURL:               "mongodb://something",
-			RedisTLS:               true,
 			HTTPServerAddr:         "localhost:1234",
 			BufferSize:             10,
 			TimestampFlushInterval: 10 * time.Minute,
@@ -44,7 +42,6 @@ var envTests = map[string]struct {
 		expectedConfig: &oplogtoredisConfiguration{
 			RedisURL:               "redis://yyy",
 			MongoURL:               "mongodb://xxx",
-			RedisTLS:               false,
 			HTTPServerAddr:         "0.0.0.0:9000",
 			BufferSize:             10000,
 			TimestampFlushInterval: time.Second,
@@ -119,11 +116,6 @@ func checkConfigExpectation(t *testing.T, expectedConfig *oplogtoredisConfigurat
 	if expectedConfig.RedisURL != RedisURL() {
 		t.Errorf("Incorrect Redis URL. Got \"%s\", Expected \"%s\"",
 			expectedConfig.RedisURL, RedisURL())
-	}
-
-	if expectedConfig.RedisTLS != RedisTLS() {
-		t.Errorf("Incorrect Redis TLS. Got \"%v\", Expected \"%v\"",
-			expectedConfig.RedisTLS, RedisTLS())
 	}
 
 	if expectedConfig.HTTPServerAddr != HTTPServerAddr() {

--- a/lib/mongourl/parse_test.go
+++ b/lib/mongourl/parse_test.go
@@ -98,7 +98,7 @@ func TestParse(t *testing.T) {
 			// Go's URL parser is pretty permissive -- bad %-escaped values are
 			// one of the few ways to get it to error.
 			URL:           "mongodb://foo/bar%",
-			expectedError: errors.New("parse mongodb://foo/bar%: invalid URL escape \"%\""),
+			expectedError: errors.New("parse \"mongodb://foo/bar%\": invalid URL escape \"%\""),
 		},
 		"bad ?maxPoolSize": {
 			URL:           "mongodb://foo?maxPoolSize=notANumber",

--- a/lib/mongourl/parse_test.go
+++ b/lib/mongourl/parse_test.go
@@ -98,7 +98,7 @@ func TestParse(t *testing.T) {
 			// Go's URL parser is pretty permissive -- bad %-escaped values are
 			// one of the few ways to get it to error.
 			URL:           "mongodb://foo/bar%",
-			expectedError: errors.New("parse \"mongodb://foo/bar%\": invalid URL escape \"%\""),
+			expectedError: errors.New("parse mongodb://foo/bar%: invalid URL escape \"%\""),
 		},
 		"bad ?maxPoolSize": {
 			URL:           "mongodb://foo?maxPoolSize=notANumber",

--- a/main.go
+++ b/main.go
@@ -176,12 +176,13 @@ func createRedisClient() (redis.UniversalClient, error) {
 	}
 
 	clientOptions := redis.UniversalOptions{
-		Addrs:    []string{parsedRedisURL.Addr},
-		DB:       parsedRedisURL.DB,
-		Password: parsedRedisURL.Password,
+		Addrs:     []string{parsedRedisURL.Addr},
+		DB:        parsedRedisURL.DB,
+		Password:  parsedRedisURL.Password,
+		TLSConfig: parsedRedisURL.TLSConfig,
 	}
 
-	if config.RedisTLS() {
+	if clientOptions.TLSConfig != nil {
 		clientOptions.TLSConfig = &tls.Config{
 			InsecureSkipVerify: false,
 			MinVersion:         tls.VersionTLS12,


### PR DESCRIPTION
Testing: Managed to connect to a redis instance on aws over TLS. 