### PR TITLE
Open up for sending the message to more than two channels

### DIFF
--- a/lib/oplog/processor.go
+++ b/lib/oplog/processor.go
@@ -75,14 +75,14 @@ func processOplogEntry(op *oplogEntry) (*redispub.Publication, error) {
 	// We need to publish on both the full-collection channel and the
 	// single-document channel
 	return &redispub.Publication{
-		// The "collection" channel is used by redis-oplog for subscriptions
-		// that target arbitrary selectors
-		CollectionChannel: op.Namespace,
-
-		// The "specific" channel is used by redis-oplog as a performance
-		// optimization for subscriptions that target a specific ID
-		SpecificChannel: op.Namespace + "::" + idForChannel,
-
+		Channels: []string{
+			// The "collection" channel is used by redis-oplog for subscriptions
+			// that target arbitrary selectors
+			op.Namespace,
+			// The "specific" channel is used by redis-oplog as a performance
+			// optimization for subscriptions that target a specific ID
+			op.Namespace + "::" + idForChannel,
+		},
 		Msg:            msgJSON,
 		OplogTimestamp: op.Timestamp,
 

--- a/lib/oplog/processor_test.go
+++ b/lib/oplog/processor_test.go
@@ -24,8 +24,7 @@ func TestProcessOplogEntry(t *testing.T) {
 		Fields []string    `json:"f"`
 	}
 	type decodedPublication struct {
-		CollectionChannel string
-		SpecificChannel   string
+		Channels          []string
 		Msg               decodedPublicationMessage
 		OplogTimestamp    bson.MongoTimestamp
 	}
@@ -53,8 +52,7 @@ func TestProcessOplogEntry(t *testing.T) {
 				Timestamp: bson.MongoTimestamp(1234),
 			},
 			want: &decodedPublication{
-				CollectionChannel: "foo.bar",
-				SpecificChannel:   "foo.bar::someid",
+				Channels: []string{"foo.bar", "foo.bar::someid"},
 				Msg: decodedPublicationMessage{
 					Event: "i",
 					Doc: map[string]interface{}{
@@ -79,8 +77,7 @@ func TestProcessOplogEntry(t *testing.T) {
 				Timestamp: bson.MongoTimestamp(1234),
 			},
 			want: &decodedPublication{
-				CollectionChannel: "foo.bar",
-				SpecificChannel:   "foo.bar::someid",
+				Channels: []string{"foo.bar", "foo.bar::someid"},
 				Msg: decodedPublicationMessage{
 					Event: "u",
 					Doc: map[string]interface{}{
@@ -111,8 +108,7 @@ func TestProcessOplogEntry(t *testing.T) {
 				Timestamp: bson.MongoTimestamp(1234),
 			},
 			want: &decodedPublication{
-				CollectionChannel: "foo.bar",
-				SpecificChannel:   "foo.bar::someid",
+				Channels: []string{"foo.bar", "foo.bar::someid"},
 				Msg: decodedPublicationMessage{
 					Event: "u",
 					Doc: map[string]interface{}{
@@ -134,8 +130,7 @@ func TestProcessOplogEntry(t *testing.T) {
 				Timestamp:  bson.MongoTimestamp(1234),
 			},
 			want: &decodedPublication{
-				CollectionChannel: "foo.bar",
-				SpecificChannel:   "foo.bar::someid",
+				Channels: []string{"foo.bar", "foo.bar::someid"},
 				Msg: decodedPublicationMessage{
 					Event: "r",
 					Doc: map[string]interface{}{
@@ -159,8 +154,7 @@ func TestProcessOplogEntry(t *testing.T) {
 				Timestamp: bson.MongoTimestamp(1234),
 			},
 			want: &decodedPublication{
-				CollectionChannel: "foo.bar",
-				SpecificChannel:   "foo.bar::deadbeefdeadbeefdeadbeef",
+				Channels: []string{"foo.bar", "foo.bar::deadbeefdeadbeefdeadbeef"},
 				Msg: decodedPublicationMessage{
 					Event: "i",
 					Doc: map[string]interface{}{
@@ -221,8 +215,7 @@ func TestProcessOplogEntry(t *testing.T) {
 		sort.Strings(msg.Fields)
 
 		return &decodedPublication{
-			CollectionChannel: pub.CollectionChannel,
-			SpecificChannel:   pub.SpecificChannel,
+			Channels:          pub.Channels,
 			Msg:               msg,
 			OplogTimestamp:    pub.OplogTimestamp,
 		}

--- a/lib/redispub/publication.go
+++ b/lib/redispub/publication.go
@@ -7,9 +7,8 @@ import (
 // Publication represents a message to be sent to Redis about an
 // oplog entry.
 type Publication struct {
-	// The two channels to send the message to
-	CollectionChannel string
-	SpecificChannel   string
+	// The channels to send the message to
+	Channels []string
 
 	// Msg is the message to send.
 	Msg []byte

--- a/lib/redispub/publisher.go
+++ b/lib/redispub/publisher.go
@@ -7,6 +7,7 @@ package redispub
 import (
 	"fmt"
 	"time"
+	"strings"
 
 	"github.com/tulip/oplogtoredis/lib/log"
 
@@ -30,8 +31,9 @@ type PublishOpts struct {
 var publishDedupe = redis.NewScript(`
 	if redis.call("GET", KEYS[1]) == false then
 		redis.call("SETEX", KEYS[1], ARGV[1], 1)
-		redis.call("PUBLISH", ARGV[3], ARGV[2])
-		redis.call("PUBLISH", ARGV[4], ARGV[2])
+		for w in string.gmatch(ARGV[3], "([^,]+)") do
+			redis.call("PUBLISH", w, ARGV[2])
+		end
 	end
 
 	return true
@@ -136,10 +138,9 @@ func publishSingleMessage(p *Publication, client redis.UniversalClient, prefix s
 			// The TxIdx field is used to ensure that each entry in a transaction has its own unique key.
 			formatKey(p, prefix),
 		},
-		dedupeExpirationSeconds, // ARGV[1], expiration time
-		p.Msg,                   // ARGV[2], message
-		p.CollectionChannel,     // ARGV[3], channel #1
-		p.SpecificChannel,       // ARGV[4], channel #2
+		dedupeExpirationSeconds,       // ARGV[1], expiration time
+		p.Msg,                         // ARGV[2], message
+		strings.Join(p.Channels, ","), // ARGV[3], channels
 	).Result()
 
 	return err

--- a/lib/redispub/publisher.go
+++ b/lib/redispub/publisher.go
@@ -31,7 +31,7 @@ type PublishOpts struct {
 var publishDedupe = redis.NewScript(`
 	if redis.call("GET", KEYS[1]) == false then
 		redis.call("SETEX", KEYS[1], ARGV[1], 1)
-		for w in string.gmatch(ARGV[3], "([^,]+)") do
+		for w in string.gmatch(ARGV[3], "([^$]+)") do
 			redis.call("PUBLISH", w, ARGV[2])
 		end
 	end
@@ -140,7 +140,7 @@ func publishSingleMessage(p *Publication, client redis.UniversalClient, prefix s
 		},
 		dedupeExpirationSeconds,       // ARGV[1], expiration time
 		p.Msg,                         // ARGV[2], message
-		strings.Join(p.Channels, ","), // ARGV[3], channels
+		strings.Join(p.Channels, "$"), // ARGV[3], channels
 	).Result()
 
 	return err

--- a/lib/redispub/publisher_test.go
+++ b/lib/redispub/publisher_test.go
@@ -17,8 +17,7 @@ import (
 
 func TestPublishSingleMessageWithRetriesImmediateSuccess(t *testing.T) {
 	publication := &Publication{
-		CollectionChannel: "a",
-		SpecificChannel:   "b",
+		Channels:          []string{"a", "b"},
 		Msg:               []byte("asdf"),
 		OplogTimestamp:    bson.MongoTimestamp(0),
 	}
@@ -47,8 +46,7 @@ func TestPublishSingleMessageWithRetriesImmediateSuccess(t *testing.T) {
 
 func TestPublishSingleMessageWithRetriesTransientFailure(t *testing.T) {
 	publication := &Publication{
-		CollectionChannel: "a",
-		SpecificChannel:   "b",
+		Channels:          []string{"a", "b"},
 		Msg:               []byte("asdf"),
 		OplogTimestamp:    bson.MongoTimestamp(0),
 	}
@@ -78,8 +76,7 @@ func TestPublishSingleMessageWithRetriesTransientFailure(t *testing.T) {
 
 func TestPublishSingleMessageWithRetriesPermanentFailure(t *testing.T) {
 	publication := &Publication{
-		CollectionChannel: "a",
-		SpecificChannel:   "b",
+		Channels:          []string{"a", "b"},
 		Msg:               []byte("asdf"),
 		OplogTimestamp:    bson.MongoTimestamp(0),
 	}


### PR DESCRIPTION
The design as currently is only allows sending a message into two channels:
* Collection channel
* Individual channel

This PR is a first improvement of this design towards supporting custom channels, as used when fine-tuning the `redis-oplog` package: https://github.com/cult-of-coders/redis-oplog/blob/master/docs/finetuning.md

It doesn't change anything on the actual result, but allows the processor to define a list of channels instead of expecting two channels.

The publisher receives the `Publication` documents and concatenates the channels, which Redis (using a LUA script) then splits again to get the list of channels in which it can send the message to.

Decision taken:
Since the arguments, passed to LUA only accepts strings, we have to concatenate the list of channels to a string - means I had to choose a separation character. Since MongoDB does neither allow the `$` sign in database nor collection names, I chose it (https://docs.mongodb.com/manual/reference/limits/#Restriction-on-Collection-Names).