### PR TITLE
GoSentinel: Added redis-sentinel support

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 buildGoModule {
   pname = "oplogtoredis";
-  version = "3.0.0";
+  version = "3.1.0";
   src = builtins.path { path = ./.; };
 
   postInstall = ''

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
         fresh -c scripts/fresh-runner.conf
     environment:
       - OTR_MONGO_URL=mongodb://mongo/dev
-      - OTR_REDIS_URL=redis://redis
+      - OTR_REDIS_URL=redis://redis,redis://redis-sentinel-master
       - OTR_LOG_DEBUG=true
     ports:
       - 9000:9000
@@ -35,3 +35,13 @@ services:
       - './.data/mongo-data:/data/db'
   redis:
     image: redis:6.0
+  
+  redis-sentinel-master:
+    image: redis:6.0
+    environment:
+      - REDIS_REPLICATION_MODE=master
+
+  redis-sentinel:
+    image: redis-sentinel:latest
+    environment:
+      - REDIS_SENTINEL_MASTER=redis-sentinel-master

--- a/integration-tests/acceptance/docker-compose.yml
+++ b/integration-tests/acceptance/docker-compose.yml
@@ -11,6 +11,10 @@ services:
         condition: service_healthy
       redis:
         condition: service_started
+      redis-sentinel:
+        condition: service_started
+      redis-sentinel-master:
+        condition: service_started
     command:
       - /wait-for.sh
       - --timeout=120
@@ -20,10 +24,14 @@ services:
       - --timeout=120
       - redis:6379
       - '--'
+      - /wait-for.sh
+      - --timeout=120
+      - redis-sentinel:26379
+      - '--'
       - /integration/acceptance/entry.sh
     environment:
       - MONGO_URL=mongodb://mongo/tests
-      - REDIS_URL=redis://redis
+      - REDIS_URL=redis://redis-sentinel:26379,redis://redis
       - OTR_URL=http://oplogtoredis:9000
   oplogtoredis:
     build:
@@ -31,13 +39,17 @@ services:
       dockerfile: ${OTR_DOCKERFILE}
     environment:
       - OTR_MONGO_URL=mongodb://mongo/tests
-      - OTR_REDIS_URL=redis://redis
+      - OTR_REDIS_URL=redis://redis-sentinel:26379,redis://redis
       - OTR_LOG_DEBUG=true
       - OTR_OPLOG_V2_EXTRACT_SUBFIELD_CHANGES=true
     depends_on:
       mongo:
         condition: service_healthy
       redis:
+        condition: service_started
+      redis-sentinel:
+        condition: service_started
+      redis-sentinel-master:
         condition: service_started
     volumes:
       - ../../scripts/wait-for.sh:/wait-for.sh
@@ -60,6 +72,16 @@ services:
     image: redis:${REDIS_TAG}
     logging:
       driver: none
+
+  redis-sentinel-master:
+    image: redis:${REDIS_TAG}
+    environment:
+      - REDIS_REPLICATION_MODE=master
+
+  redis-sentinel:
+    image: bitnami/redis-sentinel:latest
+    environment:
+      - REDIS_SENTINEL_MASTER=redis-sentinel-master
 
 volumes:
   mongo_data:

--- a/integration-tests/acceptance/harness_test.go
+++ b/integration-tests/acceptance/harness_test.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"encoding/json"
 	"sort"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/go-redis/redis/v8"
 	"github.com/kylelemons/godebug/pretty"
 	"github.com/tulip/oplogtoredis/integration-tests/helpers"
+	"github.com/tulip/oplogtoredis/lib/log"
 	"go.mongodb.org/mongo-driver/mongo"
 )
 
@@ -17,8 +19,11 @@ import (
 
 type harness struct {
 	redisClient   redis.UniversalClient
+	legacyRedisClient   redis.UniversalClient
 	subscription  *redis.PubSub
 	subscriptionC <-chan *redis.Message
+	legacySubscription  *redis.PubSub
+	legacySubscriptionC <-chan *redis.Message
 	mongoClient   *mongo.Database
 }
 
@@ -33,6 +38,10 @@ func startHarness() *harness {
 	h.subscription = h.redisClient.PSubscribe(context.Background(), "*")
 	h.subscriptionC = h.subscription.Channel()
 
+	h.legacyRedisClient = helpers.LegacyRedisClient()
+	h.legacySubscription = h.legacyRedisClient.PSubscribe(context.Background(), "*")
+	h.legacySubscriptionC = h.legacySubscription.Channel()
+
 	return &h
 }
 
@@ -41,20 +50,30 @@ func (h *harness) stop() {
 	_ = h.mongoClient.Client().Disconnect(context.Background())
 	h.redisClient.Close()
 	h.subscription.Close()
+
+	h.legacyRedisClient.Close()
+	h.legacySubscription.Close()
 }
 
 // Gets all messages sent to Redis. Returns once it hasn't seen a new message
 // in a second.
-func (h *harness) getMessages() map[string][]helpers.OTRMessage {
+func (h *harness) getMessagesHelper(legacy bool) map[string][]helpers.OTRMessage {
 	msgs := map[string][]helpers.OTRMessage{}
+	var ch <-chan *redis.Message
+	if legacy {
+		ch = h.legacySubscriptionC
+	} else {
+		ch = h.subscriptionC
+	}
 
 	for {
 		select {
-		case msg := <-h.subscriptionC:
+		case msg := <-ch:
 			parsedMsg := helpers.OTRMessage{}
 			err := json.Unmarshal([]byte(msg.Payload), &parsedMsg)
 			if err != nil {
-				panic("Error parsing JSON from redis: " + err.Error())
+				// Optional: check for sentinel related messages
+				log.Log.Debugw("Error parsing JSON from redis: " + err.Error() + "\n Response text: " + msg.Payload)
 			}
 
 			if val, ok := msgs[msg.Channel]; ok {
@@ -70,10 +89,35 @@ func (h *harness) getMessages() map[string][]helpers.OTRMessage {
 		}
 	}
 }
+func (h *harness) getMessages() map[string][]helpers.OTRMessage {
+	return h.getMessagesHelper(false)
+}
+func (h *harness) getLegacyMessages() map[string][]helpers.OTRMessage {
+	return h.getMessagesHelper(true)
+}
 
 // This is the same as getMessages, it just doesn't return the messages
 func (h *harness) resetMessages() {
 	h.getMessages()
+	h.getLegacyMessages()
+}
+func (h *harness) verifyPub(t *testing.T, pub map[string][]helpers.OTRMessage, expectedPubs map[string][]helpers.OTRMessage) {
+	for _, pubs := range pub {
+		for _, pub := range pubs {
+			sort.Strings(pub.Fields)
+		}
+
+		helpers.SortOTRMessagesByID(pubs)
+	}
+	for key := range pub {
+		if strings.Contains(key, "sentinel"){
+			delete(pub, key)
+		}
+	}
+	if diff := pretty.Compare(pub, expectedPubs); diff != "" {
+		t.Errorf("Got incorrect publications (-got +want)\n%s", diff)
+	}
+
 }
 
 // Check the publications that were actually made against the publications that
@@ -85,6 +129,7 @@ func (h *harness) verify(t *testing.T, expectedPubs map[string][]helpers.OTRMess
 	// Receive all the messages (waiting until no messages are received for a
 	// second)
 	actualPubs := h.getMessages()
+	actualLegacyPubs := h.getLegacyMessages()
 
 	// Sort the fields inside each message, and the messages themselves, before we compare
 	for _, pubs := range expectedPubs {
@@ -94,16 +139,9 @@ func (h *harness) verify(t *testing.T, expectedPubs map[string][]helpers.OTRMess
 
 		helpers.SortOTRMessagesByID(pubs)
 	}
-	for _, pubs := range actualPubs {
-		for _, pub := range pubs {
-			sort.Strings(pub.Fields)
-		}
-
-		helpers.SortOTRMessagesByID(pubs)
-	}
+	h.verifyPub(t, actualPubs, expectedPubs)
+	h.verifyPub(t, actualLegacyPubs, expectedPubs)
+	// pop the __sentinel__ entry 
 
 	// Verify the correct messages were received on each channel
-	if diff := pretty.Compare(actualPubs, expectedPubs); diff != "" {
-		t.Errorf("Got incorrect publications (-got +want)\n%s", diff)
-	}
 }

--- a/integration-tests/helpers/redis.go
+++ b/integration-tests/helpers/redis.go
@@ -2,17 +2,61 @@ package helpers
 
 import (
 	"os"
-
+	"strings"
 	"github.com/go-redis/redis/v8"
 )
 
-// RedisClient returns a redis client to the URL specified in the REDIS_URL
-// env var
-func RedisClient() *redis.Client {
-	redisOpts, err := redis.ParseURL(os.Getenv("REDIS_URL"))
+func isSentinel(url string) bool{
+	return strings.Contains(url, "sentinel")
+}
+
+func createOptions(url string, sentinel bool) (redis.UniversalOptions) {
+	redisOpts, err := redis.ParseURL(url)
 	if err != nil {
 		panic(err)
 	}
+	var clientOptions redis.UniversalOptions
+	if sentinel {
+		clientOptions = redis.UniversalOptions{
+			Addrs:     []string{redisOpts.Addr},
+			DB:        redisOpts.DB,
+			Password:  redisOpts.Password,
+			TLSConfig: redisOpts.TLSConfig,
+			MasterName: "mymaster",
+		}
+	}else{
+		clientOptions = redis.UniversalOptions{
+			Addrs:     []string{redisOpts.Addr},
+			DB:        redisOpts.DB,
+			Password:  redisOpts.Password,
+			TLSConfig: redisOpts.TLSConfig,
+		}
+	}
+	return clientOptions
+	
+}
 
-	return redis.NewClient(redisOpts)
+
+func redisClient(sentinel bool) redis.UniversalClient{
+	var urls = strings.Split(os.Getenv("REDIS_URL"), ",")
+	
+	
+	for _, url := range urls {
+		if isSentinel(url) == sentinel {
+			clientOptions := createOptions(url, sentinel)
+			return redis.NewUniversalClient(&clientOptions)
+		}
+	}
+	panic(nil)
+}
+
+func LegacyRedisClient() redis.UniversalClient {
+	return redisClient(false)
+}
+
+
+// RedisClient returns the second redis client to the URL specified in the REDIS_URL
+// The first one is the legacy fallback URL
+func RedisClient() redis.UniversalClient {
+	return redisClient(true)
 }

--- a/integration-tests/performance/docker-compose.yml
+++ b/integration-tests/performance/docker-compose.yml
@@ -11,6 +11,10 @@ services:
         condition: service_healthy
       redis:
         condition: service_started
+      redis-sentinel:
+        condition: service_started
+      redis-sentinel-master:
+        condition: service_started
     command:
       - /wait-for.sh
       - --timeout=60
@@ -20,16 +24,20 @@ services:
       - --timeout=60
       - redis:6379
       - '--'
+      - /wait-for.sh
+      - --timeout=120
+      - redis-sentinel:26379
+      - '--'
       - /integration/performance/entry.sh
     environment:
       - MONGO_URL=mongodb://mongo/tests
-      - REDIS_URL=redis://redis
+      - REDIS_URL=redis://redis-sentinel:26379,redis://redis
 
   oplogtoredis:
     build: ../..
     environment:
       - OTR_MONGO_URL=mongodb://mongo/tests
-      - OTR_REDIS_URL=redis://redis
+      - OTR_REDIS_URL=redis://redis-sentinel:26379,redis://redis
     depends_on:
       mongo:
         condition: service_healthy
@@ -64,6 +72,17 @@ services:
     image: redis:6.0
     logging:
       driver: none
+
+  redis-sentinel-master:
+    image: redis:6.0
+    environment:
+      - REDIS_REPLICATION_MODE=master
+
+  redis-sentinel:
+    image: bitnami/redis-sentinel:latest
+    environment:
+      - REDIS_SENTINEL_MASTER=redis-sentinel-master
+
 
 volumes:
   mongo_data:

--- a/lib/config/main.go
+++ b/lib/config/main.go
@@ -5,7 +5,7 @@ package config
 
 import (
 	"time"
-
+	"strings"
 	"github.com/kelseyhightower/envconfig"
 )
 
@@ -25,12 +25,11 @@ type oplogtoredisConfiguration struct {
 
 var globalConfig *oplogtoredisConfiguration
 
-// RedisURL is the Redis URL configuration. It is required, and is set via the
-// environment variable `OTR_REDIS_URL`.
-// To connect to a instance over TLS be sure to specify the url with protocol
-// `rediss://`, otherwise use `redis://`
-func RedisURL() string {
-	return globalConfig.RedisURL
+// RedisURL is the configuration for connecting to a Redis instance using the 'OTR_REDIS_URL' environment variable.
+// For TLS, use 'rediss://'; for non-TLS, use 'redis://'.
+// Multiple URLs can be configured by separating them with commas.
+func RedisURL() []string {
+	return strings.Split(globalConfig.RedisURL, ",")
 }
 
 // MongoURL is the Mongo URL configuration. Is is required, and is set via the

--- a/lib/config/main_test.go
+++ b/lib/config/main_test.go
@@ -113,7 +113,7 @@ func checkConfigExpectation(t *testing.T, expectedConfig *oplogtoredisConfigurat
 			expectedConfig.MongoURL, MongoURL())
 	}
 
-	if expectedConfig.RedisURL != RedisURL() {
+	if expectedConfig.RedisURL != strings.Join(RedisURL()[:], "") {
 		t.Errorf("Incorrect Redis URL. Got \"%s\", Expected \"%s\"",
 			expectedConfig.RedisURL, RedisURL())
 	}

--- a/lib/oplog/tail.go
+++ b/lib/oplog/tail.go
@@ -26,7 +26,7 @@ import (
 // reconnection and resumption of where it left off.
 type Tailer struct {
 	MongoClient *mongo.Client
-	RedisClient redis.UniversalClient
+	RedisClients []redis.UniversalClient
 	RedisPrefix string
 	MaxCatchUp  time.Duration
 }
@@ -397,7 +397,7 @@ func (tailer *Tailer) unmarshalEntry(rawData bson.Raw) (timestamp *primitive.Tim
 // fallback if we don't have a latest timestamp from Redis) as an arg instead
 // of using tailer.mongoClient directly so we can unit test this function
 func (tailer *Tailer) getStartTime(getTimestampOfLastOplogEntry func() (*primitive.Timestamp, error)) primitive.Timestamp {
-	ts, tsTime, redisErr := redispub.LastProcessedTimestamp(tailer.RedisClient, tailer.RedisPrefix)
+	ts, tsTime, redisErr := redispub.LastProcessedTimestamp(tailer.RedisClients[0], tailer.RedisPrefix)
 
 	if redisErr == nil {
 		// we have a last write time, check that it's not too far in the

--- a/lib/oplog/tail_test.go
+++ b/lib/oplog/tail_test.go
@@ -75,12 +75,12 @@ func TestGetStartTime(t *testing.T) {
 			defer redisServer.Close()
 			require.NoError(t, redisServer.Set("someprefix.lastProcessedEntry", strconv.FormatInt(int64(test.redisTimestamp.T), 10)))
 
-			redisClient := redis.NewUniversalClient(&redis.UniversalOptions{
+			redisClient := []redis.UniversalClient{redis.NewUniversalClient(&redis.UniversalOptions{
 				Addrs: []string{redisServer.Addr()},
-			})
+			})}
 
 			tailer := Tailer{
-				RedisClient: redisClient,
+				RedisClients: redisClient,
 				RedisPrefix: "someprefix.",
 				MaxCatchUp:  maxCatchUp,
 			}


### PR DESCRIPTION
# Added redis-sentinel support
## Patch notes:
- Made oplogtoredis mirror between multiple redis instances, given multiple, comma separated REDIS_URL's
- upgraded the tests to verify this behavior
- added sentinel support
## Testplan 
- existing integration tests and manual testing  