### PR TITLE
Use Lettuce schema for Redis Sentinel URLs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
         fresh -c scripts/fresh-runner.conf
     environment:
       - OTR_MONGO_URL=mongodb://mongo/dev
-      - OTR_REDIS_URL=redis://redis,redis://redis-sentinel-master
+      - OTR_REDIS_URL=redis://redis,redis-sentinel://redis-sentinel:26379?sentinelMasterId=mymaster
       - OTR_LOG_DEBUG=true
     ports:
       - 9000:9000

--- a/integration-tests/acceptance/docker-compose.yml
+++ b/integration-tests/acceptance/docker-compose.yml
@@ -39,7 +39,7 @@ services:
       dockerfile: ${OTR_DOCKERFILE}
     environment:
       - OTR_MONGO_URL=mongodb://mongo/tests
-      - OTR_REDIS_URL=redis://redis-sentinel:26379,redis://redis
+      - OTR_REDIS_URL=redis-sentinel://redis-sentinel:26379?sentinelMasterId=mymaster,redis://redis
       - OTR_LOG_DEBUG=true
       - OTR_OPLOG_V2_EXTRACT_SUBFIELD_CHANGES=true
     depends_on:

--- a/integration-tests/performance/docker-compose.yml
+++ b/integration-tests/performance/docker-compose.yml
@@ -37,7 +37,7 @@ services:
     build: ../..
     environment:
       - OTR_MONGO_URL=mongodb://mongo/tests
-      - OTR_REDIS_URL=redis://redis-sentinel:26379,redis://redis
+      - OTR_REDIS_URL=redis-sentinel://redis-sentinel:26379?sentinelMasterId=mymaster,redis://redis
     depends_on:
       mongo:
         condition: service_healthy

--- a/lib/parse/main.go
+++ b/lib/parse/main.go
@@ -1,0 +1,98 @@
+package parse
+
+import (
+	"net/url"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/go-redis/redis/v8"
+	"github.com/pkg/errors"
+)
+
+// parseRedisURL converts an url string, that may be a redis connection string,
+// or may be a sentinel protocol pseudo-url, into a set of redis connection options.
+func ParseRedisURL(url string, isSentinel bool) (*redis.UniversalOptions, error) {
+	if isSentinel {
+		opts, err := parseSentinelURL(url)
+		return opts, err
+	}
+
+	parsedRedisURL, err := redis.ParseURL(url)
+	if err != nil {
+		return nil, errors.Wrap(err, "Error parsing Redis URL")
+	}
+
+	// non-sentinel redis does not use MasterName, so leave it as ""
+	return &redis.UniversalOptions{
+		Addrs:     []string{parsedRedisURL.Addr},
+		DB:        parsedRedisURL.DB,
+		Password:  parsedRedisURL.Password,
+		TLSConfig: parsedRedisURL.TLSConfig,
+	}, nil
+
+}
+
+// match against redis-sentinel://[something@]something[/db]
+var urlMatcher *regexp.Regexp = regexp.MustCompile(`redis-sentinel:\/\/(([^@]+)@)?([^/]+)(\/(\d+))?`)
+
+// match against host:port
+var endpointMatcher *regexp.Regexp = regexp.MustCompile(`([^:]+):(\d+)`)
+
+// parseSentinelURL converts a sentinel protocol pseudo-url into a set of redis connection numbers.
+// we expect sentinel urls to be of the form redis-sentinel://[password@]host:port[,host2:port2][,hostN:portN][/db][?sentinelMasterId=name]
+// because of the redis-sentinel:// protocol, the protocol cannot be rediss://
+// and therefore there cannot be any tls config for the options returned from this function
+func parseSentinelURL(urlString string) (*redis.UniversalOptions, error) {
+	// the comma-separated list of host:port pairs means this is not a true url, and so must be parsed manually
+
+	// parse query params
+	queryIdx := strings.Index(urlString, "?")
+	base := urlString
+	query := ""
+	if queryIdx >= 0 {
+		base = urlString[0:queryIdx]
+		query = urlString[queryIdx+1:]
+	}
+	queryParams, err := url.ParseQuery(query)
+	if err != nil {
+		return nil, err
+	}
+	sentinelMasterId, ok := queryParams["sentinelMasterId"]
+	var name string = ""
+	if ok {
+		name = sentinelMasterId[0]
+	}
+
+	// parse base url
+	match := urlMatcher.FindStringSubmatch(base)
+	if match == nil || match[0] != base {
+		return nil, errors.New("Redis Sentinel URL did not conform to schema")
+	}
+	password := match[2]
+	endpoints := match[3]
+	dbStr := match[5]
+	// db is optional
+	db := 0
+	if dbStr != "" {
+		db, err = strconv.Atoi(dbStr)
+		if err != nil {
+			return nil, errors.Wrap(err, "Redis Sentinel URL DB is NaN")
+		}
+	}
+
+	// check endpoints parse
+	endpointsList := strings.Split(endpoints, ",")
+	for _, endpoint := range endpointsList {
+		if endpointMatcher.FindString(endpoint) != endpoint {
+			return nil, errors.New("Redis Sentinel URL Endpoints List did not conform to schema")
+		}
+	}
+
+	return &redis.UniversalOptions{
+		Password:   password,
+		Addrs:      endpointsList,
+		MasterName: name,
+		DB:         db,
+	}, nil
+}


### PR DESCRIPTION
Schema is defined here: https://github.com/lettuce-io/lettuce-core/wiki/Redis-URI-and-connection-details#uri-syntax

OTR_REDIS_URL value should be comma-separated as before, and each term should either be a regular `redis://` URL, or one of these lettuce pseudo-url entries.

Updated the docker-compose test files to use this schema for sentinel.

The tests themselves  still connect directly to the sentinel cluster, but OTR running in the tests will parse the URLs as described.