### PR TITLE
Add some new metrics

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 buildGoModule {
   pname = "oplogtoredis";
-  version = "3.2.0";
+  version = "3.3.0";
   src = builtins.path { path = ./.; };
 
   postInstall = ''

--- a/lib/oplog/tail.go
+++ b/lib/oplog/tail.go
@@ -354,7 +354,7 @@ func (tailer *Tailer) unmarshalEntry(rawData bson.Raw) (timestamp *primitive.Tim
 
 		metricOplogEntriesBySize.WithLabelValues(database, status).Observe(messageLen)
 		metricMaxOplogEntryByMinute.Report(messageLen, database, status)
-		metricLastOplogEntryStaleness.Set(float64(uint32(time.Now().Unix()) - timestamp.T))
+		metricLastOplogEntryStaleness.Set(float64(time.Since(time.Unix(int64(timestamp.T), 0))))
 	}()
 
 	if len(entries) > 0 {

--- a/lib/oplog/tail.go
+++ b/lib/oplog/tail.go
@@ -97,7 +97,7 @@ var (
 		Namespace: "otr",
 		Subsystem: "oplog",
 		Name:      "last_entry_staleness",
-		Help:      "Guage recording the difference between this server's clock and the timestamp on the last read oplog entry. This measure is confounded by the usual clock skew.",
+		Help:      "Gauge recording the difference between this server's clock and the timestamp on the last read oplog entry.",
 	})
 )
 

--- a/lib/oplog/tail.go
+++ b/lib/oplog/tail.go
@@ -96,7 +96,7 @@ var (
 	metricLastOplogEntryStaleness = promauto.NewGauge(prometheus.GaugeOpts{
 		Namespace: "otr",
 		Subsystem: "oplog",
-		Name:      "last_entry_staleness",
+		Name:      "last_entry_staleness_seconds",
 		Help:      "Gauge recording the difference between this server's clock and the timestamp on the last read oplog entry.",
 	})
 )

--- a/lib/redispub/publisher.go
+++ b/lib/redispub/publisher.go
@@ -168,7 +168,7 @@ func publishSingleMessage(p *Publication, client redis.UniversalClient, prefix s
 		strings.Join(p.Channels, "$"), // ARGV[3], channels
 	).Result()
 
-	metricLastCommandDuration.Set(time.Now().Sub(start).Seconds())
+	metricLastCommandDuration.Set(time.Since(start).Seconds())
 	return err
 }
 

--- a/lib/redispub/publisher.go
+++ b/lib/redispub/publisher.go
@@ -57,8 +57,8 @@ var metricTemporaryFailures = promauto.NewCounter(prometheus.CounterOpts{
 var metricLastCommandDuration = promauto.NewGauge(prometheus.GaugeOpts{
 	Namespace: "otr",
 	Subsystem: "redispub",
-	Name:      "last_command_duration",
-	Help:      "Number of failures encountered when trying to send a message. We automatically retry, and only register a permanent failure (in otr_redispub_processed_messages) after 30 failures.",
+	Name:      "last_command_duration_seconds",
+	Help:      "The round trip time in seconds of the most recent write to Redis.",
 })
 
 // PublishStream reads Publications from the given channel and publishes them

--- a/main.go
+++ b/main.go
@@ -78,24 +78,15 @@ func main() {
 	// and sends them to Redis.
 	//
 	// TODO PERF: Use a leaky buffer (https://github.com/tulip/oplogtoredis/issues/2)
-	bufferCapacity := 10000
-	redisPubs := make(chan *redispub.Publication, 10000)
-
-	var metricBufferCapacity = promauto.NewGauge(prometheus.GaugeOpts{
-		Namespace: "otr",
-		Subsystem: "main",
-		Name:      "buffer_capacity",
-		Help:      "Gauge indicating the capacity of the buffer that holds messages waiting to be written to redis.",
-	})
-	metricBufferCapacity.Set(float64(bufferCapacity))
+	bufferSize := 10000
+	redisPubs := make(chan *redispub.Publication, bufferSize)
 
 	promauto.NewGaugeFunc(prometheus.GaugeOpts{
 		Namespace: "otr",
-		Subsystem: "main",
-		Name:      "buffer_contents",
-		Help:      "Guage indicating the number of messages waiting in the buffer to be written to redis.",
+		Name:      "buffer_available",
+		Help:      "Gauge indicating the available space in the buffer of oplog entries waiting to be written to redis.",
 	}, func () float64 {
-		return float64(len(redisPubs))
+		return float64(bufferSize - len(redisPubs))
 	})
 
 	waitGroup := sync.WaitGroup{}


### PR DESCRIPTION
Adds a few new metrics:

- `otr_pubsub_last_command_duration_seconds`
- `otr_oplog_last_entry_staleness_seconds`
- `otr_buffer_available`

This has been baking in staging since before the weekend and seems to be working nicely.