### PR TITLE
Add pprof endpoints

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 buildGoModule {
   pname = "oplogtoredis";
-  version = "3.1.0";
+  version = "3.2.0";
   src = builtins.path { path = ./.; };
 
   postInstall = ''
@@ -10,7 +10,7 @@ buildGoModule {
 
   # update: set value to an empty string and run `nix build`. This will download Go, fetch the dependencies and calculates their hash.
   vendorHash = "sha256-ceToA2DC1bhmg9WIeNSAfoNoU7sk9PrQqgqt5UbpivQ=";
-  
+
   nativeBuildInputs = [ installShellFiles ];
   doCheck = false;
   doInstallCheck = false;

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	stdlog "log"
 	"net/http"
+	"net/http/pprof"
 	"os"
 	"os/signal"
 	"strings"
@@ -256,6 +257,12 @@ func makeHTTPServer(clients []redis.UniversalClient, mongo *mongo.Client) *http.
 	})
 
 	mux.Handle("/metrics", promhttp.Handler())
+
+	mux.HandleFunc("/debug/pprof/", pprof.Index)
+	mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+	mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+	mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+	mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
 
 	return &http.Server{Addr: config.HTTPServerAddr(), Handler: mux}
 }


### PR DESCRIPTION
Update oplogtoredis to serve the standard net/http/pprof routes from its existing HTTP server. You can try it out by running `go tool pprof http://<host and port for oplogtoredis>`.