### PR TITLE
Update various usages of `docker-compose` to `docker compose`

### DIFF
--- a/scripts/runBlackboxTests.sh
+++ b/scripts/runBlackboxTests.sh
@@ -12,7 +12,7 @@ rm -f $CERTS_DIR/*
 
 function cleanup() {
   rm -rf blackbox-tests/certificates
-  docker-compose -f blackbox-tests/docker-compose.yml down --volumes
+  docker compose -f blackbox-tests/docker-compose.yml down --volumes
 }
 
 # # GENERATE CERTS FOR ENABLING TLS
@@ -22,7 +22,7 @@ docker run \
   cert-generator
 
 # BRING UP OPLOGTOREDIS
-docker-compose -f blackbox-tests/docker-compose.yml up -d --build
+docker compose -f blackbox-tests/docker-compose.yml up -d --build
 
 # WAIT FOR OPLOGTOREDIS TO START
 # network=host only works on linux, so if running from a mac/windows
@@ -35,7 +35,7 @@ else
 fi
 
 # INSERT DATA INTO MONGO
-docker-compose -f blackbox-tests/docker-compose.yml exec -T \
+docker compose -f blackbox-tests/docker-compose.yml exec -T \
   mongo sh -c \
   'mongo --eval "db.products.insert( { item: \"card\", qty: 15 } )"'
 
@@ -43,14 +43,14 @@ docker-compose -f blackbox-tests/docker-compose.yml exec -T \
 # xargs is a hack to get rid of whitespace
 # if oplogtoredis transmitted oplog to redis, we should have 2 entries
 RESULT=$(
-  docker-compose -f blackbox-tests/docker-compose.yml exec -T \
+  docker compose -f blackbox-tests/docker-compose.yml exec -T \
     redis sh -c \
     'redis-cli --scan --pattern "*" | wc -l | xargs')
 
 echo "Num keys received: $RESULT"
 if [[  $RESULT != 2 ]] ; then
   echo "Test failed, number of inserted keys does not match expected value"
-  echo "cleaning up: running docker-compose down"
+  echo "cleaning up: running docker compose down"
   cleanup
   exit 3
 else

--- a/scripts/runIntegrationAcceptance.sh
+++ b/scripts/runIntegrationAcceptance.sh
@@ -3,7 +3,7 @@
 set -eu
 cd "$(dirname "$0")/../integration-tests/acceptance"
 
-# Use docker-compose to spin up the test environment
+# Use docker compose to spin up the test environment
 mongo_tags=( "4.4" "5.0.19" )
 redis_tags=( "6.0" )
 otr_dockerfiles=( "Dockerfile" "Dockerfile.racedetector" )
@@ -34,9 +34,9 @@ for mongo_tag in "${mongo_tags[@]}"; do
 
             export MONGO_ARGS
 
-            docker-compose rm -vf
-            docker-compose down -v
-            docker-compose up \
+            docker compose rm -vf
+            docker compose down -v
+            docker compose up \
                 --build \
                 --exit-code-from test \
                 --abort-on-container-exit

--- a/scripts/runIntegrationAcceptanceSingle.sh
+++ b/scripts/runIntegrationAcceptanceSingle.sh
@@ -3,7 +3,7 @@
 set -eu
 cd "$(dirname "$0")/../integration-tests/acceptance"
 
-# Use docker-compose to spin up the test environment
+# Use docker compose to spin up the test environment
 mongo_tag="5.0.19"
 redis_tag="6.2.5"
 otr_dockerfile="Dockerfile.racedetector"
@@ -24,9 +24,9 @@ export OTR_DOCKERFILE="$otr_dockerfile"
 
 export MONGO_ARGS=""
 
-docker-compose rm -vf
-docker-compose down -v
-docker-compose up \
+docker compose rm -vf
+docker compose down -v
+docker compose up \
     --build \
     --exit-code-from test \
     --abort-on-container-exit

--- a/scripts/runIntegrationMeteor.sh
+++ b/scripts/runIntegrationMeteor.sh
@@ -3,9 +3,9 @@
 set -eu
 cd `dirname "$0"`'/../integration-tests/meteor'
 
-docker-compose rm -vf
-docker-compose down -v
-docker-compose up \
+docker compose rm -vf
+docker compose down -v
+docker compose up \
     --build \
     --exit-code-from test \
     --abort-on-container-exit

--- a/scripts/runIntegrationPerformance.sh
+++ b/scripts/runIntegrationPerformance.sh
@@ -3,9 +3,9 @@
 set -eu
 cd `dirname "$0"`'/../integration-tests/performance'
 
-docker-compose rm -vf
-docker-compose down -v
-docker-compose up \
+docker compose rm -vf
+docker compose down -v
+docker compose up \
     --build \
     --exit-code-from test \
     --abort-on-container-exit


### PR DESCRIPTION
CI broke as of 2024/04/01 because of [this](https://github.com/actions/runner-images/issues/9557). I update all of the references to `docker-compose` to `docker compose` as recommended, which seems to have fixed it. All jobs passed, and at least some of them ran on the new image (I'm not entirely sure what controls this; perhaps which runner the job hits?), which tells me that this change works in both circumstances.