### PR TITLE
Add epoch-seconds timestamp to debug logs of oplog entries

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 buildGoModule {
   pname = "oplogtoredis";
-  version = "3.3.0";
+  version = "3.4.0";
   src = builtins.path { path = ./.; };
 
   postInstall = ''

--- a/lib/oplog/tail.go
+++ b/lib/oplog/tail.go
@@ -340,8 +340,7 @@ func (tailer *Tailer) unmarshalEntry(rawData bson.Raw) (timestamp *primitive.Tim
 	timestamp = &result.Timestamp
 
 	entries := tailer.parseRawOplogEntry(result, nil)
-	log.Log.Debugw("Received oplog entry",
-		"entry", result)
+	log.Log.Debugw("Received oplog entry", "entry", result, "processTime", time.Now().UnixMilli())
 
 	status := "ignored"
 	database := "(no database)"


### PR DESCRIPTION
When we get an oplog entry, we log it out at debug level. This adds an extra metadata field that prints the server time in seconds since the epoch so that it's easy to see visually how delayed oplog entries are.