### PR TITLE
Oplogtoredis: Add configurable Write Parallelism

### DIFF
--- a/lib/config/main.go
+++ b/lib/config/main.go
@@ -22,7 +22,7 @@ type oplogtoredisConfiguration struct {
 	MongoConnectTimeout           time.Duration `default:"10s" split_words:"true"`
 	MongoQueryTimeout             time.Duration `default:"5s" split_words:"true"`
 	OplogV2ExtractSubfieldChanges bool          `default:"false" envconfig:"OPLOG_V2_EXTRACT_SUBFIELD_CHANGES"`
-	WriteParallelism              int           `default:"1" spit_words:"true"`
+	WriteParallelism              int           `default:"1" split_words:"true"`
 }
 
 var globalConfig *oplogtoredisConfiguration

--- a/lib/config/main.go
+++ b/lib/config/main.go
@@ -4,8 +4,9 @@
 package config
 
 import (
-	"time"
 	"strings"
+	"time"
+
 	"github.com/kelseyhightower/envconfig"
 )
 
@@ -21,6 +22,7 @@ type oplogtoredisConfiguration struct {
 	MongoConnectTimeout           time.Duration `default:"10s" split_words:"true"`
 	MongoQueryTimeout             time.Duration `default:"5s" split_words:"true"`
 	OplogV2ExtractSubfieldChanges bool          `default:"false" envconfig:"OPLOG_V2_EXTRACT_SUBFIELD_CHANGES"`
+	WriteParallelism              int           `default:"1" spit_words:"true"`
 }
 
 var globalConfig *oplogtoredisConfiguration
@@ -129,6 +131,13 @@ func MongoQueryTimeout() time.Duration {
 // to change without notice.
 func OplogV2ExtractSubfieldChanges() bool {
 	return globalConfig.OplogV2ExtractSubfieldChanges
+}
+
+// WriteParallelism controls how many parallel write loops will be run (sharded based on a hash
+// of the database name.) Each parallel loop has its own redis connection and internal buffer.
+// Healthz endpoint will report fail if anyone of them dies.
+func WriteParallelism() int {
+	return globalConfig.WriteParallelism
 }
 
 // ParseEnv parses the current environment variables and updates the stored

--- a/lib/oplog/processor_test.go
+++ b/lib/oplog/processor_test.go
@@ -14,6 +14,9 @@ import (
 	"go.mongodb.org/mongo-driver/bson"
 )
 
+// hash of the database name "foo" to be expected for ParallelismKey
+const fooHash = -5843589418109203719
+
 // nolint: gocyclo
 func TestProcessOplogEntry(t *testing.T) {
 	// We can't compare raw publications because they contain JSON that can
@@ -25,9 +28,10 @@ func TestProcessOplogEntry(t *testing.T) {
 		Fields []string    `json:"f"`
 	}
 	type decodedPublication struct {
-		Channels          []string
-		Msg               decodedPublicationMessage
-		OplogTimestamp    primitive.Timestamp
+		Channels       []string
+		Msg            decodedPublicationMessage
+		OplogTimestamp primitive.Timestamp
+		ParallelismKey int
 	}
 
 	testObjectId, err := primitive.ObjectIDFromHex("deadbeefdeadbeefdeadbeef")
@@ -67,6 +71,7 @@ func TestProcessOplogEntry(t *testing.T) {
 					Fields: []string{"some"},
 				},
 				OplogTimestamp: primitive.Timestamp{T: 1234},
+				ParallelismKey: fooHash,
 			},
 		},
 		"Replacement update": {
@@ -92,6 +97,7 @@ func TestProcessOplogEntry(t *testing.T) {
 					Fields: []string{"some", "new"},
 				},
 				OplogTimestamp: primitive.Timestamp{T: 1234},
+				ParallelismKey: fooHash,
 			},
 		},
 		"Non-replacement update": {
@@ -123,6 +129,7 @@ func TestProcessOplogEntry(t *testing.T) {
 					Fields: []string{"a", "b", "c"},
 				},
 				OplogTimestamp: primitive.Timestamp{T: 1234},
+				ParallelismKey: fooHash,
 			},
 		},
 		"Delete": {
@@ -145,6 +152,7 @@ func TestProcessOplogEntry(t *testing.T) {
 					Fields: []string{},
 				},
 				OplogTimestamp: primitive.Timestamp{T: 1234},
+				ParallelismKey: fooHash,
 			},
 		},
 		"ObjectID id": {
@@ -172,6 +180,7 @@ func TestProcessOplogEntry(t *testing.T) {
 					Fields: []string{"some"},
 				},
 				OplogTimestamp: primitive.Timestamp{T: 1234},
+				ParallelismKey: fooHash,
 			},
 		},
 		"Unsupported id type": {
@@ -242,9 +251,10 @@ func TestProcessOplogEntry(t *testing.T) {
 		sort.Strings(msg.Fields)
 
 		return &decodedPublication{
-			Channels:          pub.Channels,
-			Msg:               msg,
-			OplogTimestamp:    pub.OplogTimestamp,
+			Channels:       pub.Channels,
+			Msg:            msg,
+			OplogTimestamp: pub.OplogTimestamp,
+			ParallelismKey: pub.ParallelismKey,
 		}
 	}
 

--- a/lib/oplog/tail.go
+++ b/lib/oplog/tail.go
@@ -25,10 +25,10 @@ import (
 // Tailer persistently tails the oplog of a Mongo cluster, handling
 // reconnection and resumption of where it left off.
 type Tailer struct {
-	MongoClient *mongo.Client
+	MongoClient  *mongo.Client
 	RedisClients []redis.UniversalClient
-	RedisPrefix string
-	MaxCatchUp  time.Duration
+	RedisPrefix  string
+	MaxCatchUp   time.Duration
 }
 
 // Raw oplog entry from Mongo
@@ -107,7 +107,7 @@ func init() {
 
 // Tail begins tailing the oplog. It doesn't return unless it receives a message
 // on the stop channel, in which case it wraps up its work and then returns.
-func (tailer *Tailer) Tail(out chan<- *redispub.Publication, stop <-chan bool) {
+func (tailer *Tailer) Tail(out []chan<- *redispub.Publication, stop <-chan bool) {
 	childStopC := make(chan bool)
 	wasStopped := false
 
@@ -131,7 +131,7 @@ func (tailer *Tailer) Tail(out chan<- *redispub.Publication, stop <-chan bool) {
 	}
 }
 
-func (tailer *Tailer) tailOnce(out chan<- *redispub.Publication, stop <-chan bool) {
+func (tailer *Tailer) tailOnce(out []chan<- *redispub.Publication, stop <-chan bool) {
 	session, err := tailer.MongoClient.StartSession()
 	if err != nil {
 		log.Log.Errorw("Failed to start Mongo session", "error", err)
@@ -203,7 +203,8 @@ func (tailer *Tailer) tailOnce(out chan<- *redispub.Publication, stop <-chan boo
 
 				for _, pub := range pubs {
 					if pub != nil {
-						out <- pub
+						outIdx := pub.ParallelismKey % len(out)
+						out[outIdx] <- pub
 					} else {
 						log.Log.Error("Nil Redis publication")
 					}

--- a/lib/oplog/tail.go
+++ b/lib/oplog/tail.go
@@ -132,6 +132,8 @@ func (tailer *Tailer) Tail(out []chan<- *redispub.Publication, stop <-chan bool)
 }
 
 func (tailer *Tailer) tailOnce(out []chan<- *redispub.Publication, stop <-chan bool) {
+	parallelismSize := len(out)
+
 	session, err := tailer.MongoClient.StartSession()
 	if err != nil {
 		log.Log.Errorw("Failed to start Mongo session", "error", err)
@@ -203,7 +205,7 @@ func (tailer *Tailer) tailOnce(out []chan<- *redispub.Publication, stop <-chan b
 
 				for _, pub := range pubs {
 					if pub != nil {
-						outIdx := pub.ParallelismKey % len(out)
+						outIdx := (pub.ParallelismKey%parallelismSize + parallelismSize) % parallelismSize
 						out[outIdx] <- pub
 					} else {
 						log.Log.Error("Nil Redis publication")

--- a/lib/redispub/publication.go
+++ b/lib/redispub/publication.go
@@ -20,4 +20,8 @@ type Publication struct {
 
 	// TxIdx is the index of the operation within a transaction. Used to supplement OplogTimestamp in a transaction.
 	TxIdx uint
+
+	// ParallelismKey is a number representing which parallel write loop will process this message.
+	// It is a hash of the database name, assuming that a single database is the unit of ordering guarantee.
+	ParallelismKey int
 }


### PR DESCRIPTION
This adds a new configuration option, OTR_WRITE_PARALLELISM. This will be an integer that controls how many parallel writer loops deliver the oplog messages to Redis. Each oplog message will be routed to one of the loops based on a SHA256 hash of its database name. The value defaults to 1 if unspecified, which means it parallelism is off by default (since a parallelism of 1 means a single writer, the same as currently).