### PR TITLE
OplogToRedis: Read Parallelism

### DIFF
--- a/integration-tests/fault-injection/redisStopStart_test.go
+++ b/integration-tests/fault-injection/redisStopStart_test.go
@@ -61,6 +61,7 @@ func TestRedisStopStart(t *testing.T) {
 
 	nSuccess := harness.FindPromMetricCounter(metrics, "otr_redispub_processed_messages", map[string]string{
 		"status": "sent",
+		"idx":    "0",
 	})
 	if nSuccess != 100 {
 		t.Errorf("Metric otr_redispub_processed_messages(status: sent) = %d, expected 100", nSuccess)
@@ -68,6 +69,7 @@ func TestRedisStopStart(t *testing.T) {
 
 	nPermFail := harness.FindPromMetricCounter(metrics, "otr_redispub_processed_messages", map[string]string{
 		"status": "failed",
+		"idx":    "0",
 	})
 	if nPermFail != 0 {
 		t.Errorf("Metric otr_redispub_processed_messages(status: failed) = %d, expected 0", nPermFail)

--- a/lib/config/main.go
+++ b/lib/config/main.go
@@ -23,6 +23,7 @@ type oplogtoredisConfiguration struct {
 	MongoQueryTimeout             time.Duration `default:"5s" split_words:"true"`
 	OplogV2ExtractSubfieldChanges bool          `default:"false" envconfig:"OPLOG_V2_EXTRACT_SUBFIELD_CHANGES"`
 	WriteParallelism              int           `default:"1" split_words:"true"`
+	ReadParallelism               int           `default:"1" split_words:"true"`
 }
 
 var globalConfig *oplogtoredisConfiguration
@@ -138,6 +139,14 @@ func OplogV2ExtractSubfieldChanges() bool {
 // Healthz endpoint will report fail if anyone of them dies.
 func WriteParallelism() int {
 	return globalConfig.WriteParallelism
+}
+
+// ReadParallelism controls how many parallel read loops will be run. Each read loop has its own mongo
+// connection. Each loop consumes the entire oplog, but will hash the database name and discard any
+// messages that don't match the loop's ordinal (effectively the same shard algorithm the write loops use).
+// Healthz endpoint will report fail if anyone of them dies.
+func ReadParallelism() int {
+	return globalConfig.ReadParallelism
 }
 
 // ParseEnv parses the current environment variables and updates the stored

--- a/lib/oplog/tail.go
+++ b/lib/oplog/tail.go
@@ -546,8 +546,10 @@ func parseNamespace(namespace string) (string, string) {
 }
 
 // assignToShard determines which shard should process a given key.
-// This should just be key % shardCount, but Go modulo is weird with negative numbers,
-// and the parallelism key can be negative.
+// The key is an integer generated from random bytes, which means it can be negative.
+// In Go, A%B when A is negative produces a negative result, which is inadequate as an
+// array index. We fix this by doing (A%B+B)%B, which is identical to A%B for positive A
+// and produces the expected result for negative A.
 func assignToShard(key int, shardCount int) int {
 	return (key%shardCount + shardCount) % shardCount
 }

--- a/lib/oplog/tail.go
+++ b/lib/oplog/tail.go
@@ -149,7 +149,7 @@ func (tailer *Tailer) tailOnce(out []chan<- *redispub.Publication, stop <-chan b
 
 	oplogCollection := session.Client().Database("local").Collection("oplog.rs")
 
-	startTime := tailer.getStartTime(parallelismSize-1, func() (*primitive.Timestamp, error) {
+	startTime := tailer.getStartTime(len(out)-1, func() (*primitive.Timestamp, error) {
 		// Get the timestamp of the last entry in the oplog (as a position to
 		// start from if we don't have a last-written timestamp from Redis)
 		var entry rawOplogEntry

--- a/main.go
+++ b/main.go
@@ -50,7 +50,7 @@ func main() {
 	waitGroup := sync.WaitGroup{}
 	denylist := sync.Map{}
 
-	for i := 0; i < config.WriteParallelism(); i++ {
+	for i := 0; i < writeParallelism; i++ {
 		redisClients, err := createRedisClients()
 		if err != nil {
 			panic(fmt.Sprintf("[%d] Error initializing Redis client: %s", i, err.Error()))
@@ -106,8 +106,7 @@ func main() {
 		})
 	}
 
-	// TODO create a separate env var for this
-	readParallelism := config.WriteParallelism()
+	readParallelism := config.ReadParallelism()
 
 	stopOplogTails := make([]chan bool, readParallelism)
 	aggregatedMongoSessions := make([]*mongo.Client, readParallelism)

--- a/main.go
+++ b/main.go
@@ -280,7 +280,7 @@ func makeHTTPServer(aggregatedClients [][]redis.UniversalClient, aggregatedMongo
 		mongoOK := true
 		for _, mongo := range aggregatedMongos {
 			mongoErr := mongo.Ping(ctx, readpref.Primary())
-			mongoOK := (mongoOK && (mongoErr == nil))
+			mongoOK = (mongoOK && (mongoErr == nil))
 			if !mongoOK {
 				log.Log.Errorw("Error connecting to Mongo during healthz check",
 					"error", mongoErr)


### PR DESCRIPTION
This is a follow-on to https://github.com/tulip/oplogtoredis/pull/70.

This adds read parallelism in addition to the write-parallelism. Every read routine has its own Mongo session, and will consume the entire oplog. When processing a message, the same hash that is used to route the message to the appropriate write routine will be first compared to the ordinal of the read routine. If it doesn't match, it will simply be discarded. The result of this is that every message will be processed by exactly one read routine.

The read routines need not correspond one-to-one with the write routines.