### PR TITLE
OplogToRedis: Improve metrics handling for parallelism

### DIFF
--- a/lib/oplog/tail.go
+++ b/lib/oplog/tail.go
@@ -415,6 +415,7 @@ func (tailer *Tailer) unmarshalEntry(rawData bson.Raw, denylist *sync.Map) (time
 // fallback if we don't have a latest timestamp from Redis) as an arg instead
 // of using tailer.mongoClient directly so we can unit test this function
 func (tailer *Tailer) getStartTime(maxOrdinal int, getTimestampOfLastOplogEntry func() (*primitive.Timestamp, error)) primitive.Timestamp {
+	// Get the earliest "last processed time" for each shard. This assumes that the number of shards is constant.
 	ts, tsTime, redisErr := redispub.FirstLastProcessedTimestamp(tailer.RedisClients[0], tailer.RedisPrefix, maxOrdinal)
 
 	if redisErr == nil {

--- a/lib/oplog/tail.go
+++ b/lib/oplog/tail.go
@@ -144,7 +144,7 @@ func (tailer *Tailer) tailOnce(out []chan<- *redispub.Publication, stop <-chan b
 
 	oplogCollection := session.Client().Database("local").Collection("oplog.rs")
 
-	startTime := tailer.getStartTime(func() (*primitive.Timestamp, error) {
+	startTime := tailer.getStartTime(parallelismSize-1, func() (*primitive.Timestamp, error) {
 		// Get the timestamp of the last entry in the oplog (as a position to
 		// start from if we don't have a last-written timestamp from Redis)
 		var entry rawOplogEntry
@@ -414,8 +414,8 @@ func (tailer *Tailer) unmarshalEntry(rawData bson.Raw, denylist *sync.Map) (time
 // We take the function to get the timestamp of the last oplog entry (as a
 // fallback if we don't have a latest timestamp from Redis) as an arg instead
 // of using tailer.mongoClient directly so we can unit test this function
-func (tailer *Tailer) getStartTime(getTimestampOfLastOplogEntry func() (*primitive.Timestamp, error)) primitive.Timestamp {
-	ts, tsTime, redisErr := redispub.LastProcessedTimestamp(tailer.RedisClients[0], tailer.RedisPrefix)
+func (tailer *Tailer) getStartTime(maxOrdinal int, getTimestampOfLastOplogEntry func() (*primitive.Timestamp, error)) primitive.Timestamp {
+	ts, tsTime, redisErr := redispub.FirstLastProcessedTimestamp(tailer.RedisClients[0], tailer.RedisPrefix, maxOrdinal)
 
 	if redisErr == nil {
 		// we have a last write time, check that it's not too far in the

--- a/lib/oplog/tail.go
+++ b/lib/oplog/tail.go
@@ -95,13 +95,6 @@ var (
 		},
 	}, []string{"database", "status"})
 
-	metricLastOplogEntryStaleness = promauto.NewGauge(prometheus.GaugeOpts{
-		Namespace: "otr",
-		Subsystem: "oplog",
-		Name:      "last_entry_staleness_seconds",
-		Help:      "Gauge recording the difference between this server's clock and the timestamp on the last read oplog entry.",
-	})
-
 	metricOplogEntriesFiltered = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "otr",
 		Subsystem: "oplog",
@@ -365,7 +358,6 @@ func (tailer *Tailer) unmarshalEntry(rawData bson.Raw, denylist *sync.Map) (time
 
 		metricOplogEntriesBySize.WithLabelValues(database, status).Observe(messageLen)
 		metricMaxOplogEntryByMinute.Report(messageLen, database, status)
-		metricLastOplogEntryStaleness.Set(float64(time.Since(time.Unix(int64(timestamp.T), 0))))
 	}()
 
 	if len(entries) > 0 {

--- a/lib/oplog/tail_test.go
+++ b/lib/oplog/tail_test.go
@@ -74,7 +74,7 @@ func TestGetStartTime(t *testing.T) {
 				panic(err)
 			}
 			defer redisServer.Close()
-			require.NoError(t, redisServer.Set("someprefix.lastProcessedEntry", strconv.FormatInt(int64(test.redisTimestamp.T), 10)))
+			require.NoError(t, redisServer.Set("someprefix.lastProcessedEntry.0", strconv.FormatInt(int64(test.redisTimestamp.T), 10)))
 
 			redisClient := []redis.UniversalClient{redis.NewUniversalClient(&redis.UniversalOptions{
 				Addrs: []string{redisServer.Addr()},
@@ -87,7 +87,7 @@ func TestGetStartTime(t *testing.T) {
 				Denylist:     &sync.Map{},
 			}
 
-			actualResult := tailer.getStartTime(func() (*primitive.Timestamp, error) {
+			actualResult := tailer.getStartTime(0, func() (*primitive.Timestamp, error) {
 				if test.mongoEndOfOplogErr != nil {
 					return nil, test.mongoEndOfOplogErr
 				}

--- a/lib/redispub/lastProcessedTime.go
+++ b/lib/redispub/lastProcessedTime.go
@@ -2,6 +2,7 @@ package redispub
 
 import (
 	"context"
+	"strconv"
 	"time"
 
 	"github.com/go-redis/redis/v8"
@@ -17,8 +18,8 @@ import (
 //
 // If oplogtoredis has not processed any messages, returns redis.Nil as an
 // error.
-func LastProcessedTimestamp(redisClient redis.UniversalClient, metadataPrefix string) (primitive.Timestamp, time.Time, error) {
-	str, err := redisClient.Get(context.Background(), metadataPrefix+"lastProcessedEntry").Result()
+func LastProcessedTimestamp(redisClient redis.UniversalClient, metadataPrefix string, ordinal int) (primitive.Timestamp, time.Time, error) {
+	str, err := redisClient.Get(context.Background(), metadataPrefix+"lastProcessedEntry."+strconv.Itoa(ordinal)).Result()
 	if err != nil {
 		return primitive.Timestamp{}, time.Unix(0, 0), err
 	}
@@ -30,4 +31,23 @@ func LastProcessedTimestamp(redisClient redis.UniversalClient, metadataPrefix st
 
 	time := mongoTimestampToTime(ts)
 	return ts, time, nil
+}
+
+// FirstLastProcessedTimestamp runs LastProcessedTimestamp for each ordinal up to the provided count,
+// then returns the earliest such timestamp obtained. If any ordinal produces an error, that error is returned.
+func FirstLastProcessedTimestamp(redisClient redis.UniversalClient, metadataPrefix string, maxOrdinal int) (primitive.Timestamp, time.Time, error) {
+	var minTs primitive.Timestamp
+	var minTime time.Time
+	for i := 0; i <= maxOrdinal; i++ {
+		ts, time, err := LastProcessedTimestamp(redisClient, metadataPrefix, i)
+		if err != nil {
+			return ts, time, err
+		}
+
+		if i == 0 || ts.Before(minTs) {
+			minTs = ts
+			minTime = time
+		}
+	}
+	return minTs, minTime, nil
 }

--- a/lib/redispub/lastProcessedTime_test.go
+++ b/lib/redispub/lastProcessedTime_test.go
@@ -31,9 +31,9 @@ func TestLastProcessedTimestampSuccess(t *testing.T) {
 	redisServer, redisClient := startMiniredis()
 	defer redisServer.Close()
 
-	require.NoError(t, redisServer.Set("someprefix.lastProcessedEntry", encodeMongoTimestamp(nowTS)))
+	require.NoError(t, redisServer.Set("someprefix.lastProcessedEntry.0", encodeMongoTimestamp(nowTS)))
 
-	gotTS, gotTime, err := LastProcessedTimestamp(redisClient, "someprefix.")
+	gotTS, gotTime, err := LastProcessedTimestamp(redisClient, "someprefix.", 0)
 
 	if err != nil {
 		t.Errorf("Got unexpected error: %s", err)
@@ -52,7 +52,7 @@ func TestLastProcessedTimestampNoRecord(t *testing.T) {
 	redisServer, redisClient := startMiniredis()
 	defer redisServer.Close()
 
-	_, _, err := LastProcessedTimestamp(redisClient, "someprefix.")
+	_, _, err := LastProcessedTimestamp(redisClient, "someprefix.", 0)
 
 	if err == nil {
 		t.Errorf("Expected redis.Nil error, got no error")
@@ -64,9 +64,9 @@ func TestLastProcessedTimestampNoRecord(t *testing.T) {
 func TestLastProcessedTimestampInvalidRecord(t *testing.T) {
 	redisServer, redisClient := startMiniredis()
 	defer redisServer.Close()
-	require.NoError(t, redisServer.Set("someprefix.lastProcessedEntry", "not a number"))
+	require.NoError(t, redisServer.Set("someprefix.lastProcessedEntry.0", "not a number"))
 
-	_, _, err := LastProcessedTimestamp(redisClient, "someprefix.")
+	_, _, err := LastProcessedTimestamp(redisClient, "someprefix.", 0)
 
 	if err == nil {
 		t.Errorf("Expected strconv error, got no error")
@@ -80,7 +80,7 @@ func TestLastProcessedTimestampRedisError(t *testing.T) {
 		Addrs: []string{"not a server"},
 	})
 
-	_, _, err := LastProcessedTimestamp(redisClient, "someprefix.")
+	_, _, err := LastProcessedTimestamp(redisClient, "someprefix.", 0)
 
 	if err == nil {
 		t.Errorf("Expected TCP error, got no error")

--- a/lib/redispub/publisher.go
+++ b/lib/redispub/publisher.go
@@ -156,7 +156,7 @@ func publishSingleMessageWithRetries(p *Publication, maxRetries int, sleepTime t
 
 func publishSingleMessage(p *Publication, client redis.UniversalClient, prefix string, dedupeExpirationSeconds int, ordinal int) error {
 	start := time.Now()
-	metricLastOplogEntryStaleness.WithLabelValues(strconv.Itoa(ordinal)).Set(float64(time.Since(time.Unix(int64(p.OplogTimestamp.T), 0))))
+	metricLastOplogEntryStaleness.WithLabelValues(strconv.Itoa(ordinal)).Set(float64(time.Since(time.Unix(int64(p.OplogTimestamp.T), 0)).Seconds()))
 
 	_, err := publishDedupe.Run(
 		context.Background(),

--- a/lib/redispub/publisher_test.go
+++ b/lib/redispub/publisher_test.go
@@ -121,11 +121,11 @@ func TestPeriodicallyUpdateTimestamp(t *testing.T) {
 		periodicallyUpdateTimestamp(redisClient, timestampC, &PublishOpts{
 			MetadataPrefix: "someprefix.",
 			FlushInterval:  testSpeed,
-		})
+		}, 0)
 		waitGroup.Done()
 	}()
 
-	key := "someprefix.lastProcessedEntry"
+	key := "someprefix.lastProcessedEntry.0"
 
 	// Key should be unset
 	if redisServer.Exists(key) {

--- a/main.go
+++ b/main.go
@@ -69,16 +69,16 @@ func main() {
 		if err != nil {
 			panic(fmt.Sprintf("[%d] Error initializing Redis client: %s", i, err.Error()))
 		}
-		defer func() {
+		defer func(ordinal int) {
 			for _, redisClient := range redisClients {
 				redisCloseErr := redisClient.Close()
 				if redisCloseErr != nil {
 					log.Log.Errorw("Error closing Redis client",
 						"error", redisCloseErr,
-						"i", i)
+						"i", ordinal)
 				}
 			}
-		}()
+		}(i)
 		log.Log.Infow("Initialized connection to Redis", "i", i)
 
 		aggregatedRedisClients[i] = redisClients
@@ -104,7 +104,7 @@ func main() {
 				DedupeExpiration: config.RedisDedupeExpiration(),
 				MetadataPrefix:   config.RedisMetadataPrefix(),
 			}, stopRedisPub, ordinal)
-			log.Log.Infow("Redis publisher completed", "i", i)
+			log.Log.Infow("Redis publisher completed", "i", ordinal)
 			waitGroup.Done()
 		}(i)
 		log.Log.Info("Started up processing goroutines")

--- a/main.go
+++ b/main.go
@@ -98,15 +98,15 @@ func main() {
 
 		stopRedisPub := make(chan bool)
 		waitGroup.Add(1)
-		go func() {
+		go func(ordinal int) {
 			redispub.PublishStream(redisClients, redisPubs, &redispub.PublishOpts{
 				FlushInterval:    config.TimestampFlushInterval(),
 				DedupeExpiration: config.RedisDedupeExpiration(),
 				MetadataPrefix:   config.RedisMetadataPrefix(),
-			}, stopRedisPub)
+			}, stopRedisPub, ordinal)
 			log.Log.Infow("Redis publisher completed", "i", i)
 			waitGroup.Done()
-		}()
+		}(i)
 		log.Log.Info("Started up processing goroutines")
 		stopRedisPubs[i] = stopRedisPub
 	}


### PR DESCRIPTION
Collection of a few metrics improvements:
- staleness metric is now on the publisher side instead of on the tail side
- staleness metric is now sharded by write parallelism
- lastprocessedtimestamp now computed separately per write parallelism, and the minimum is taken
- use proper coroutine variable reference when spinning up parallel coroutines in main to guarantee correct logs