### PR TITLE
OplogToRedis: Make Denylist Deletion Idempotent

### DIFF
--- a/lib/denylist/http.go
+++ b/lib/denylist/http.go
@@ -115,7 +115,7 @@ func deleteDenylistEntry(response http.ResponseWriter, request *http.Request, de
 	}
 	_, exists := denylist.Load(id)
 	if !exists {
-		http.Error(response, "denylist entry not found with that id", http.StatusNotFound)
+		response.WriteHeader(http.StatusNoContent)
 		return
 	}
 


### PR DESCRIPTION
If you try to DELETE at /denylist/:id and `id` doesn't exist on the denylist, the server will return 204 instead of 404, so that it can be done multiple times without producing an error.