### PR TITLE
OplogToRedis: Persistent Denylist

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -9,7 +9,7 @@ buildGoModule {
   '';
 
   # update: set value to an empty string and run `nix build`. This will download Go, fetch the dependencies and calculates their hash.
-  vendorHash = "sha256-Vh7O0iMPG6nAvcyv92h5TVZS2awnR0vz75apyzJeu4c=";
+  vendorHash = "sha256-S7/phL8nEYNVeDPqGjh3OAqVB8nOmYk0XDhD7op3fa4=";
 
   nativeBuildInputs = [ installShellFiles ];
   doCheck = false;

--- a/go.mod
+++ b/go.mod
@@ -39,6 +39,7 @@ require (
 	github.com/juju/loggo v0.0.0-20200526014432-9ce3a2e09b5e // indirect
 	github.com/juju/utils/v2 v2.0.0-20200923005554-4646bfea2ef1 // indirect
 	github.com/klauspost/compress v1.13.6 // indirect
+	github.com/lib/pq v1.10.9 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
 	github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -214,6 +214,8 @@ github.com/kvz/logstreamer v0.0.0-20201023134116-02d20f4338f5 h1:dkCjlgGN81ahDFt
 github.com/kvz/logstreamer v0.0.0-20201023134116-02d20f4338f5/go.mod h1:8/LTPeDLaklcUjgSQBHbhBF1ibKAFxzS5o+H7USfMSA=
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
+github.com/lib/pq v1.10.9 h1:YXG7RB+JIjhP29X+OtkiDnYaXQwpS4JEWq7dtCCRUEw=
+github.com/lib/pq v1.10.9/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/lunixbochs/vtclean v0.0.0-20160125035106-4fbf7632a2c6/go.mod h1:pHhQNgMf3btfWnGBVipUOjRYhoOsdGqdm/+2c2E2WMI=
 github.com/masterzen/azure-sdk-for-go v3.2.0-beta.0.20161014135628-ee4f0065d00c+incompatible/go.mod h1:mf8fjOu33zCqxUjuiU3I8S1lJMyEAlH+0F2+M5xl3hE=
 github.com/masterzen/simplexml v0.0.0-20160608183007-4572e39b1ab9/go.mod h1:kCEbxUJlNDEBNbdQMkPSp6yaKcRXVI6f4ddk8Riv4bc=

--- a/integration-tests/acceptance/denylist_http_test.go
+++ b/integration-tests/acceptance/denylist_http_test.go
@@ -1,87 +1,53 @@
 package main
 
 import (
-	"bytes"
-	"encoding/json"
-	"io"
-	"net/http"
 	"os"
 	"reflect"
 	"testing"
+
+	"github.com/tulip/oplogtoredis/integration-tests/helpers"
 )
-
-func doRequest(method string, path string, t *testing.T, expectedCode int) interface{} {
-	req, err := http.NewRequest(method, os.Getenv("OTR_URL")+path, &bytes.Buffer{})
-	if err != nil {
-		t.Fatalf("Error creating req: %s", err)
-	}
-	req.Header.Set("Content-Type", "application/json")
-	resp, err := (&http.Client{}).Do(req)
-	if err != nil {
-		t.Fatalf("Error sending request: %s", err)
-	}
-
-	defer resp.Body.Close()
-
-	respBody, err := io.ReadAll(resp.Body)
-	if err != nil {
-		t.Fatalf("Error eceiving response body: %s", err)
-	}
-
-	if resp.StatusCode != expectedCode {
-		t.Fatalf("Expected status code %d, but got %d.\nBody was: %s", expectedCode, resp.StatusCode, respBody)
-	}
-
-	if expectedCode == 200 {
-		var data interface{}
-		err = json.Unmarshal(respBody, &data)
-		if err != nil {
-			t.Fatalf("Error parsing JSON response: %s", err)
-		}
-
-		return data
-	}
-	return nil
-}
 
 // Test the /denylist HTTP operations
 func TestDenyList(t *testing.T) {
+	baseURL := os.Getenv("OTR_URL")
+
 	// GET empty list of rules
-	data := doRequest("GET", "/denylist", t, 200)
+	data := helpers.DoRequest("GET", baseURL, "/denylist", t, 200)
 	if !reflect.DeepEqual(data, []interface{}{}) {
 		t.Fatalf("Expected empty list from blank GET, but got %#v", data)
 	}
 	// PUT new rule
-	doRequest("PUT", "/denylist/abc", t, 201)
+	helpers.DoRequest("PUT", baseURL, "/denylist/abc", t, 201)
 	// GET list with new rule in it
-	data = doRequest("GET", "/denylist", t, 200)
+	data = helpers.DoRequest("GET", baseURL, "/denylist", t, 200)
 	if !reflect.DeepEqual(data, []interface{}{"abc"}) {
 		t.Fatalf("Expected singleton from GET, but got %#v", data)
 	}
 	// GET existing rule
-	data = doRequest("GET", "/denylist/abc", t, 200)
+	data = helpers.DoRequest("GET", baseURL, "/denylist/abc", t, 200)
 	if !reflect.DeepEqual(data, "abc") {
 		t.Fatalf("Expected matched body from GET, but got %#v", data)
 	}
 	// PUT second rule
-	doRequest("PUT", "/denylist/def", t, 201)
+	helpers.DoRequest("PUT", baseURL, "/denylist/def", t, 201)
 	// GET second rule
-	data = doRequest("GET", "/denylist/def", t, 200)
+	data = helpers.DoRequest("GET", baseURL, "/denylist/def", t, 200)
 	if !reflect.DeepEqual(data, "def") {
 		t.Fatalf("Expected matched body from GET, but got %#v", data)
 	}
 	// GET list with both rules
-	data = doRequest("GET", "/denylist", t, 200)
+	data = helpers.DoRequest("GET", baseURL, "/denylist", t, 200)
 	// check both permutations, in case the server reordered them
 	if !reflect.DeepEqual(data, []interface{}{"abc", "def"}) && !reflect.DeepEqual(data, []interface{}{"def", "abc"}) {
 		t.Fatalf("Expected doubleton from GET, but got %#v", data)
 	}
 	// DELETE first rule
-	doRequest("DELETE", "/denylist/abc", t, 204)
+	helpers.DoRequest("DELETE", baseURL, "/denylist/abc", t, 204)
 	// GET first rule
-	doRequest("GET", "/denylist/abc", t, 404)
+	helpers.DoRequest("GET", baseURL, "/denylist/abc", t, 404)
 	// GET list with only second rule
-	data = doRequest("GET", "/denylist", t, 200)
+	data = helpers.DoRequest("GET", baseURL, "/denylist", t, 200)
 	if !reflect.DeepEqual(data, []interface{}{"def"}) {
 		t.Fatalf("Expected singleton from GET, but got %#V", data)
 	}

--- a/integration-tests/acceptance/denylist_oplog_test.go
+++ b/integration-tests/acceptance/denylist_oplog_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"os"
 	"testing"
 
 	"github.com/tulip/oplogtoredis/integration-tests/helpers"
@@ -9,6 +10,8 @@ import (
 )
 
 func TestDenyOplog(t *testing.T) {
+	baseURL := os.Getenv("OTR_URL")
+
 	harness := startHarness()
 	defer harness.stop()
 
@@ -33,7 +36,7 @@ func TestDenyOplog(t *testing.T) {
 		"tests.Foo::id1": {expectedMessage1},
 	})
 
-	doRequest("PUT", "/denylist/tests", t, 201)
+	helpers.DoRequest("PUT", baseURL, "/denylist/tests", t, 201)
 
 	_, err = harness.mongoClient.Collection("Foo").InsertOne(context.Background(), bson.M{
 		"_id": "id2",
@@ -46,7 +49,7 @@ func TestDenyOplog(t *testing.T) {
 	// second message should not have been received, since it got denied
 	harness.verify(t, map[string][]helpers.OTRMessage{})
 
-	doRequest("DELETE", "/denylist/tests", t, 204)
+	helpers.DoRequest("DELETE", baseURL, "/denylist/tests", t, 204)
 
 	_, err = harness.mongoClient.Collection("Foo").InsertOne(context.Background(), bson.M{
 		"_id": "id3",

--- a/integration-tests/fault-injection/Dockerfile
+++ b/integration-tests/fault-injection/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update && \
   apt-get install -y \
   jq \
   netcat \
+  postgresql \
   musl && \
   rm -rf /var/lib/apt/lists/*
 

--- a/integration-tests/fault-injection/denylist_persistence_test.go
+++ b/integration-tests/fault-injection/denylist_persistence_test.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/tulip/oplogtoredis/integration-tests/fault-injection/harness"
+	"github.com/tulip/oplogtoredis/integration-tests/helpers"
+)
+
+// This test restarts oplogtoredis after adding denylist entries.
+// We expect the entries to still be there afterward, and be removable.
+func TestDenylistPersistence(t *testing.T) {
+	mongo := harness.StartMongoServer()
+	defer mongo.Stop()
+
+	// Sleeping here for a while as the initial connection seems to be unreliable
+	time.Sleep(time.Second * 1)
+
+	redis := harness.StartRedisServer()
+	defer redis.Stop()
+
+	pg := harness.StartPostgresServer()
+	defer pg.Stop()
+
+	otr := harness.StartOTRProcessWithEnv(mongo.Addr, redis.Addr, 9000, []string{
+		fmt.Sprintf("OTR_PG_PERSISTENCE_URL=\"%s\"", pg.ConnStr),
+	})
+	defer otr.Stop()
+
+	time.Sleep(3 * time.Second)
+
+	baseURL := "http://localhost:9000"
+	// PUT new rule
+	helpers.DoRequest("PUT", baseURL, "/denylist/abc", t, 201)
+	// PUT second rule
+	helpers.DoRequest("PUT", baseURL, "/denylist/def", t, 201)
+	// GET list with both rules
+	data := helpers.DoRequest("GET", baseURL, "/denylist", t, 200)
+	// check both permutations, in case the server reordered them
+	if !reflect.DeepEqual(data, []interface{}{"abc", "def"}) && !reflect.DeepEqual(data, []interface{}{"def", "abc"}) {
+		t.Fatalf("Expected doubleton from GET, but got %#v", data)
+	}
+
+	otr.Stop()
+	time.Sleep(3 * time.Second)
+	otr.Start()
+
+	time.Sleep(3 * time.Second)
+
+	// denylist should have persisted across the restart
+
+	// GET list with both rules
+	data = helpers.DoRequest("GET", baseURL, "/denylist", t, 200)
+	// check both permutations, in case the server reordered them
+	if !reflect.DeepEqual(data, []interface{}{"abc", "def"}) && !reflect.DeepEqual(data, []interface{}{"def", "abc"}) {
+		t.Fatalf("Expected doubleton from GET, but got %#v", data)
+	}
+
+	// denylist should still be modifiable
+
+	// DELETE first rule
+	helpers.DoRequest("DELETE", baseURL, "/denylist/abc", t, 204)
+	// GET list with only second rule
+	data = helpers.DoRequest("GET", baseURL, "/denylist", t, 200)
+	if !reflect.DeepEqual(data, []interface{}{"def"}) {
+		t.Fatalf("Expected singleton from GET, but got %#V", data)
+	}
+}

--- a/integration-tests/fault-injection/denylist_persistence_test.go
+++ b/integration-tests/fault-injection/denylist_persistence_test.go
@@ -26,7 +26,7 @@ func TestDenylistPersistence(t *testing.T) {
 	defer pg.Stop()
 
 	otr := harness.StartOTRProcessWithEnv(mongo.Addr, redis.Addr, 9000, []string{
-		fmt.Sprintf("OTR_PG_PERSISTENCE_URL=\"%s\"", pg.ConnStr),
+		fmt.Sprintf("OTR_PG_PERSISTENCE_URL=%s", pg.ConnStr),
 	})
 	defer otr.Stop()
 

--- a/integration-tests/fault-injection/denylist_persistence_test.go
+++ b/integration-tests/fault-injection/denylist_persistence_test.go
@@ -25,6 +25,9 @@ func TestDenylistPersistence(t *testing.T) {
 	pg := harness.StartPostgresServer()
 	defer pg.Stop()
 
+	// wait before starting OTR for the auth changes to take effects
+	time.Sleep(3 * time.Second)
+
 	otr := harness.StartOTRProcessWithEnv(mongo.Addr, redis.Addr, 9000, []string{
 		fmt.Sprintf("OTR_PG_PERSISTENCE_URL=%s", pg.ConnStr),
 	})

--- a/integration-tests/fault-injection/harness/postgres.go
+++ b/integration-tests/fault-injection/harness/postgres.go
@@ -35,7 +35,7 @@ func StartPostgresServer() *PostgresServer {
 		"--",
 		"psql",
 		"-c",
-		"\"ALTER USER postgres WITH PASSWORD 'postgres';\"",
+		"ALTER USER postgres WITH PASSWORD 'postgres';",
 	)
 
 	return &PostgresServer{

--- a/integration-tests/fault-injection/harness/postgres.go
+++ b/integration-tests/fault-injection/harness/postgres.go
@@ -1,0 +1,53 @@
+package harness
+
+import (
+	"os/exec"
+)
+
+type PostgresServer struct {
+	ConnStr string
+}
+
+func runCommandWithLogs(name string, args ...string) {
+	cmd := exec.Command(name, args...)
+	cmd.Stderr = makeLogStreamer("postgres", "stderr")
+	cmd.Stdout = makeLogStreamer("postgres", "stdout")
+	err := cmd.Start()
+	if err != nil {
+		panic("Error starting up postgres: " + err.Error())
+	}
+}
+
+func StartPostgresServer() *PostgresServer {
+	runCommandWithLogs(
+		"pg_ctlcluster",
+		"11",
+		"main",
+		"start",
+	)
+
+	waitTCP("127.0.0.1:5432")
+
+	runCommandWithLogs(
+		"runuser",
+		"-u",
+		"postgres",
+		"--",
+		"psql",
+		"-c",
+		"\"ALTER USER postgres WITH PASSWORD 'postgres';\"",
+	)
+
+	return &PostgresServer{
+		ConnStr: "postgres://postgres:postgres@localhost/postgres",
+	}
+}
+
+func (server *PostgresServer) Stop() {
+	runCommandWithLogs(
+		"pg_ctlcluster",
+		"11",
+		"main",
+		"stop",
+	)
+}

--- a/integration-tests/helpers/http.go
+++ b/integration-tests/helpers/http.go
@@ -1,0 +1,43 @@
+package helpers
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+)
+
+func DoRequest(method string, baseURL string, path string, t *testing.T, expectedCode int) interface{} {
+	req, err := http.NewRequest(method, baseURL+path, &bytes.Buffer{})
+	if err != nil {
+		t.Fatalf("Error creating req: %s", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := (&http.Client{}).Do(req)
+	if err != nil {
+		t.Fatalf("Error sending request: %s", err)
+	}
+
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("Error eceiving response body: %s", err)
+	}
+
+	if resp.StatusCode != expectedCode {
+		t.Fatalf("Expected status code %d, but got %d.\nBody was: %s", expectedCode, resp.StatusCode, respBody)
+	}
+
+	if expectedCode == 200 {
+		var data interface{}
+		err = json.Unmarshal(respBody, &data)
+		if err != nil {
+			t.Fatalf("Error parsing JSON response: %s", err)
+		}
+
+		return data
+	}
+	return nil
+}

--- a/lib/config/main.go
+++ b/lib/config/main.go
@@ -24,6 +24,7 @@ type oplogtoredisConfiguration struct {
 	OplogV2ExtractSubfieldChanges bool          `default:"false" envconfig:"OPLOG_V2_EXTRACT_SUBFIELD_CHANGES"`
 	WriteParallelism              int           `default:"1" split_words:"true"`
 	ReadParallelism               int           `default:"1" split_words:"true"`
+	PostgresPersistenceURL        string        `envconfig:"PG_PERSISTENCE_URL"`
 }
 
 var globalConfig *oplogtoredisConfiguration
@@ -147,6 +148,12 @@ func WriteParallelism() int {
 // Healthz endpoint will report fail if anyone of them dies.
 func ReadParallelism() int {
 	return globalConfig.ReadParallelism
+}
+
+// PostgresPersistenceURL is the optional configuration for persisting a denylist entry to a postgres database
+// If configured, the denylist will be written to the DB on every change, and loaded on startup
+func PostgresPersistenceURL() string {
+	return globalConfig.PostgresPersistenceURL
 }
 
 // ParseEnv parses the current environment variables and updates the stored

--- a/lib/config/main.go
+++ b/lib/config/main.go
@@ -24,7 +24,7 @@ type oplogtoredisConfiguration struct {
 	OplogV2ExtractSubfieldChanges bool          `default:"false" envconfig:"OPLOG_V2_EXTRACT_SUBFIELD_CHANGES"`
 	WriteParallelism              int           `default:"1" split_words:"true"`
 	ReadParallelism               int           `default:"1" split_words:"true"`
-	PostgresPersistenceURL        string        `envconfig:"PG_PERSISTENCE_URL"`
+	PostgresPersistenceURL        string        `default:"" envconfig:"PG_PERSISTENCE_URL"`
 }
 
 var globalConfig *oplogtoredisConfiguration

--- a/lib/denylist/http.go
+++ b/lib/denylist/http.go
@@ -102,7 +102,11 @@ func createDenylistEntry(response http.ResponseWriter, request *http.Request, de
 	denylist.Store(id, true)
 	log.Log.Infow("Created denylist entry", "id", id)
 	metricFilterEnabled.WithLabelValues(id).Set(1)
-	syncer.StoreDenylistEntry(denylist, id)
+	err := syncer.StoreDenylistEntry(denylist, id)
+	if err != nil {
+		http.Error(response, "failed to persist removal of denylist entry", http.StatusInternalServerError)
+		return
+	}
 
 	response.WriteHeader(http.StatusCreated)
 }
@@ -123,7 +127,11 @@ func deleteDenylistEntry(response http.ResponseWriter, request *http.Request, de
 	denylist.Delete(id)
 	log.Log.Infow("Deleted denylist entry", "id", id)
 	metricFilterEnabled.WithLabelValues(id).Set(0)
-	syncer.DeleteDenylistEntry(denylist, id)
+	err := syncer.DeleteDenylistEntry(denylist, id)
+	if err != nil {
+		http.Error(response, "failed to persist removal of denylist entry", http.StatusInternalServerError)
+		return
+	}
 
 	response.WriteHeader(http.StatusNoContent)
 }

--- a/lib/denylist/pg.go
+++ b/lib/denylist/pg.go
@@ -1,0 +1,79 @@
+package denylist
+
+import (
+	"database/sql"
+	"sync"
+
+	_ "github.com/lib/pq"
+)
+
+type Syncer struct {
+	Persistent bool
+	Handle     *sql.DB
+}
+
+func NewSyncer(persistenceURL string) (*Syncer, error) {
+	if persistenceURL == "" {
+		return &Syncer{
+			Persistent: false,
+		}, nil
+	}
+
+	db, err := sql.Open("postgres", persistenceURL)
+	if err != nil {
+		return nil, err
+	}
+	return &Syncer{
+		Persistent: true,
+		Handle:     db,
+	}, nil
+}
+
+func (syncer *Syncer) LoadDenylist() (*sync.Map, error) {
+	if syncer.Persistent {
+		_, err := syncer.Handle.Exec("CREATE TABLE IF NOT EXISTS otr_denylist (entry VARCHAR(255) UNIQUE);")
+		if err != nil {
+			return nil, err
+		}
+		rows, err := syncer.Handle.Query("SELECT entry FROM otr_denylist;")
+		if err != nil {
+			return nil, err
+		}
+		var entry string
+		denylist := sync.Map{}
+		for rows.Next() {
+			err = rows.Scan(&entry)
+			if err != nil {
+				return nil, err
+			}
+			denylist.Store(entry, true)
+		}
+		return &denylist, nil
+	}
+
+	return &sync.Map{}, nil
+}
+
+func (syncer *Syncer) StoreDenylistEntry(denylist *sync.Map, id string) error {
+	if syncer.Persistent {
+		_, err := syncer.Handle.Exec("INSERT INTO otr_denylist (entry) VALUES ($1) ON CONFLICT DO NOTHING;", id)
+		if err != nil {
+			return err
+		}
+		return nil
+	}
+
+	return nil
+}
+
+func (syncer *Syncer) DeleteDenylistEntry(denylist *sync.Map, id string) error {
+	if syncer.Persistent {
+		_, err := syncer.Handle.Exec("DELETE FROM otr_denylist WHERE entry=$1;", id)
+		if err != nil {
+			return err
+		}
+		return nil
+	}
+
+	return nil
+}


### PR DESCRIPTION
Persist the configurable denylist across a restart.

The service takes an optional environment variable configuration option `OTR_PG_PERSISTENCE_URL` to a postgres database.
The service will create a table `otr_denylist` with one column (a list of unique denylist entries).
The service will write to the table whenever entries are created or removed.
Since all OTR replicas should have the same denylist, this should be fine- first to add adds, and first to delete deletes.

The service will read the table contents at startup to populate the initial denylist.
This should make the service resilient to restarting after a denylist entry was added.
The HTTP methods should only respond 2xx after writing to the DB, so persistence failures will be known by the calling context.