### PR TITLE
Fix meteor test Dockerfile

### DIFF
--- a/integration-tests/meteor/docker-compose.yml
+++ b/integration-tests/meteor/docker-compose.yml
@@ -38,7 +38,7 @@ services:
     environment:
       - OTR_MONGO_URL=mongodb://mongo/tests
       - OTR_REDIS_URL=redis://redis
-      # - OTR_LOG_DEBUG=true
+      - OTR_LOG_DEBUG=true
       - OTR_OPLOG_V2_EXTRACT_SUBFIELD_CHANGES=true
     depends_on:
       mongo:

--- a/testapp/Dockerfile
+++ b/testapp/Dockerfile
@@ -6,7 +6,7 @@ ENV METEOR_ALLOW_SUPERUSER=true
 RUN apt-get update && \
   apt-get install -y g++ build-essential curl && \
   rm -rf /var/lib/apt/lists/* && \
-  curl https://install.meteor.com/ | sh
+  curl https://install.meteor.com/?release=2.13 | sh
 
 RUN meteor create --release 2.5.6 /throwaway && rm -rf /throwaway
 


### PR DESCRIPTION
The docker installation wasn't pinned to a version, and the newer version was causing the test to fail.