### PR TITLE
Correction for objectID issue in last merge

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 buildGoModule {
   pname = "oplogtoredis";
-  version = "3.7.0";
+  version = "3.7.1";
   src = builtins.path { path = ./.; };
 
   postInstall = ''

--- a/lib/oplog/tail.go
+++ b/lib/oplog/tail.go
@@ -522,7 +522,7 @@ func (tailer *Tailer) parseRawOplogEntry(entry rawOplogEntry, txIdx *uint) []opl
 				if ok {
 					out.DocID = oidString
 				} else {
-					log.Log.Error("failed to get objectId: _id is not ObjectID or String type")
+					log.Log.Error("failed to get objectId: _id is not ObjectID or String type", idLookup.String())
 					return nil
 				}
 			}

--- a/lib/oplog/tail.go
+++ b/lib/oplog/tail.go
@@ -515,7 +515,7 @@ func (tailer *Tailer) parseRawOplogEntry(entry rawOplogEntry, txIdx *uint) []opl
 			}
 			err := idLookup.Unmarshal(&out.DocID)
 			if err != nil {
-				log.Log.Error("failed to get objectId: _id is not ObjectID or String type", idLookup.String())
+				log.Log.Error("failed to unmarshal objectId", err)
 				return nil
 			}
 		}

--- a/lib/oplog/tail.go
+++ b/lib/oplog/tail.go
@@ -515,7 +515,7 @@ func (tailer *Tailer) parseRawOplogEntry(entry rawOplogEntry, txIdx *uint) []opl
 			}
 			err := idLookup.Unmarshal(&out.DocID)
 			if err != nil {
-				log.Log.Error("failed to unmarshal objectId", err)
+				log.Log.Errorf("failed to unmarshal objectId: %v", err)
 				return nil
 			}
 		}

--- a/lib/oplog/tail.go
+++ b/lib/oplog/tail.go
@@ -522,7 +522,7 @@ func (tailer *Tailer) parseRawOplogEntry(entry rawOplogEntry, txIdx *uint) []opl
 				if ok {
 					out.DocID = oidString
 				} else {
-					log.Log.Errorf("failed to get objectId: _id is not ObjectID or String type")
+					log.Log.Error("failed to get objectId: _id is not ObjectID or String type")
 					return nil
 				}
 			}

--- a/lib/oplog/tail.go
+++ b/lib/oplog/tail.go
@@ -510,21 +510,13 @@ func (tailer *Tailer) parseRawOplogEntry(entry rawOplogEntry, txIdx *uint) []opl
 		} else {
 			idLookup := entry.Doc.Lookup("_id")
 			if idLookup.IsZero() {
-				log.Log.Errorf("failed to get objectId: _id is empty or not set")
+				log.Log.Error("failed to get objectId: _id is empty or not set")
 				return nil
 			}
-			oid, ok := idLookup.ObjectIDOK()
-			if ok {
-				// this is left as ObjectID type for now so it can be properly converted in processor.go:56
-				out.DocID = oid
-			} else {
-				oidString, ok := idLookup.StringValueOK()
-				if ok {
-					out.DocID = oidString
-				} else {
-					log.Log.Error("failed to get objectId: _id is not ObjectID or String type", idLookup.String())
-					return nil
-				}
+			err := idLookup.Unmarshal(&out.DocID)
+			if err != nil {
+				log.Log.Error("failed to get objectId: _id is not ObjectID or String type", idLookup.String())
+				return nil
 			}
 		}
 


### PR DESCRIPTION
The last PR merged decode the objectID as either string or objectId type, but would fail on binary objectIDs.  The prior implementation had converted the objectID to an interface{} type, to be handled downstream, so this moves back to that approach, while still limiting the unmarshaling to just the _id field.