### PR TITLE
Sentry fix

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 buildGoModule {
   pname = "oplogtoredis";
-  version = "3.7.1";
+  version = "3.7.2";
   src = builtins.path { path = ./.; };
 
   postInstall = ''

--- a/lib/log/main.go
+++ b/lib/log/main.go
@@ -94,6 +94,8 @@ func sentryInit(log *zap.Logger) *zap.Logger {
 		},
 	}
 
+	defaultSentryClient = sentry.CurrentHub().Client()
+
 	core, err := zapsentry.NewCore(cfg, zapsentry.NewSentryClientFromClient(defaultSentryClient))
 
 	if err != nil {
@@ -105,6 +107,7 @@ func sentryInit(log *zap.Logger) *zap.Logger {
 	log = zapsentry.AttachCoreToLogger(core, log).With(zapsentry.NewScope())
 
 	log.Info("Sentry wrapper configured")
+	log.Error("Sentry error test")
 
 	return log
 }

--- a/lib/log/main.go
+++ b/lib/log/main.go
@@ -107,7 +107,6 @@ func sentryInit(log *zap.Logger) *zap.Logger {
 	log = zapsentry.AttachCoreToLogger(core, log).With(zapsentry.NewScope())
 
 	log.Info("Sentry wrapper configured")
-	log.Error("Sentry error test")
 
 	return log
 }


### PR DESCRIPTION
The sentry client wasn't initialized, causing a segfault when reporting error logs.  The fix was tested by creating a test error after init, and confirm that the error showed up in Sentry.