### PR TITLE
Improve initial metadata read using bson instead of unmarshal

### DIFF
--- a/lib/oplog/tail.go
+++ b/lib/oplog/tail.go
@@ -375,13 +375,11 @@ func unmarshalEntryMetadata(rawData bson.Raw, denylist *sync.Map) *rawOplogEntry
 	}
 
 	// try to filter early if possible
-	if len(result.Namespace) > 0 { 
+	if len(result.Namespace) > 0 && result.Namespace != "admin.$cmd" {
 		db, _ := parseNamespace(result.Namespace)
-
 		if _, denied := denylist.Load(db); denied {
 			log.Log.Debugw("Skipping oplog entry", "database", db)
 			metricOplogEntriesFiltered.WithLabelValues(db).Add(1)
-
 			return nil
 		}
 	}

--- a/lib/oplog/tail.go
+++ b/lib/oplog/tail.go
@@ -378,6 +378,10 @@ func (tailer *Tailer) processEntry(rawData bson.Raw, readOrdinal int) (timestamp
 	status := "ignored"
 	database := "(no database)"
 	messageLen := float64(len(rawData))
+	
+	if len(entries) > 0 {
+		database = entries[0].Database
+	}
 
 	sendMetricsData = func() {
 		// TODO: remove these in a future version

--- a/lib/oplog/tail.go
+++ b/lib/oplog/tail.go
@@ -549,7 +549,7 @@ func (tailer *Tailer) parseRawOplogEntry(entry rawOplogEntry, txIdx *uint) []opl
 		} else {
 			out.DocID, errID = parseID(entry.Doc.Lookup("_id"))
 		}
-		if(errID != nil) {
+		if errID != nil {
 			return nil
 		}
 

--- a/lib/oplog/tail_test.go
+++ b/lib/oplog/tail_test.go
@@ -104,16 +104,6 @@ func TestGetStartTime(t *testing.T) {
 	}
 }
 
-func mustRaw(t *testing.T, data interface{}) bson.Raw {
-	b, err := bson.Marshal(data)
-	require.NoError(t, err)
-
-	var raw bson.Raw
-	require.NoError(t, bson.Unmarshal(b, &raw))
-
-	return raw
-}
-
 func TestParseRawOplogEntry(t *testing.T) {
 	tests := map[string]struct {
 		in   rawOplogEntry
@@ -124,7 +114,7 @@ func TestParseRawOplogEntry(t *testing.T) {
 				Timestamp: primitive.Timestamp{T: 1234},
 				Operation: "i",
 				Namespace: "foo.Bar",
-				Doc:       mustRaw(t, map[string]interface{}{"_id": "someid", "foo": "bar"}),
+				Doc:       rawBson(t, map[string]interface{}{"_id": "someid", "foo": "bar"}),
 			},
 			want: []oplogEntry{{
 				Timestamp:  primitive.Timestamp{T: 1234},
@@ -141,7 +131,7 @@ func TestParseRawOplogEntry(t *testing.T) {
 				Timestamp: primitive.Timestamp{T: 1234},
 				Operation: "u",
 				Namespace: "foo.Bar",
-				Doc:       mustRaw(t, map[string]interface{}{"new": "data"}),
+				Doc:       rawBson(t, map[string]interface{}{"new": "data"}),
 				Update:    rawBson(t, map[string]interface{}{"_id": "updateid"}),
 			},
 			want: []oplogEntry{{
@@ -159,7 +149,7 @@ func TestParseRawOplogEntry(t *testing.T) {
 				Timestamp: primitive.Timestamp{T: 1234},
 				Operation: "d",
 				Namespace: "foo.Bar",
-				Doc:       mustRaw(t, map[string]interface{}{"_id": "someid"}),
+				Doc:       rawBson(t, map[string]interface{}{"_id": "someid"}),
 			},
 			want: []oplogEntry{{
 				Timestamp:  primitive.Timestamp{T: 1234},
@@ -176,7 +166,7 @@ func TestParseRawOplogEntry(t *testing.T) {
 				Timestamp: primitive.Timestamp{T: 1234},
 				Operation: "c",
 				Namespace: "foo.$cmd",
-				Doc:       mustRaw(t, map[string]interface{}{"drop": "Foo"}),
+				Doc:       rawBson(t, map[string]interface{}{"drop": "Foo"}),
 			},
 			want: nil,
 		},
@@ -185,51 +175,51 @@ func TestParseRawOplogEntry(t *testing.T) {
 				Timestamp: primitive.Timestamp{T: 1234},
 				Operation: "c",
 				Namespace: "admin.$cmd",
-				Doc: mustRaw(t, map[string]interface{}{
+				Doc: rawBson(t, map[string]interface{}{
 					"applyOps": []rawOplogEntry{
 						{
 							Timestamp: primitive.Timestamp{T: 1234},
 							Operation: "c",
 							Namespace: "admin.$cmd",
-							Doc: mustRaw(t, map[string]interface{}{
+							Doc: rawBson(t, map[string]interface{}{
 								"applyOps": []rawOplogEntry{
 									{
 										Operation: "i",
 										Namespace: "foo.Bar",
-										Doc: mustRaw(t, map[string]interface{}{
+										Doc: rawBson(t, map[string]interface{}{
 											"_id": "id1",
 											"foo": "baz",
 										}),
-										Update: mustRaw(t, map[string]interface{}{}),
+										Update: rawBson(t, map[string]interface{}{}),
 									},
 								},
 							}),
-							Update: mustRaw(t, map[string]interface{}{}),
+							Update: rawBson(t, map[string]interface{}{}),
 						},
 						{
 							Operation: "i",
 							Namespace: "foo.Bar",
-							Doc: mustRaw(t, map[string]interface{}{
+							Doc: rawBson(t, map[string]interface{}{
 								"_id": "id1",
 								"foo": "bar",
 							}),
-							Update: mustRaw(t, map[string]interface{}{}),
+							Update: rawBson(t, map[string]interface{}{}),
 						},
 						{
 							Operation: "u",
 							Namespace: "foo.Bar",
-							Doc: mustRaw(t, map[string]interface{}{
+							Doc: rawBson(t, map[string]interface{}{
 								"foo": "quux",
 							}),
-							Update: mustRaw(t, map[string]interface{}{"_id": "id2"}),
+							Update: rawBson(t, map[string]interface{}{"_id": "id2"}),
 						},
 						{
 							Operation: "d",
 							Namespace: "foo.Bar",
-							Doc: mustRaw(t, map[string]interface{}{
+							Doc: rawBson(t, map[string]interface{}{
 								"_id": "id3",
 							}),
-							Update: mustRaw(t, map[string]interface{}{}),
+							Update: rawBson(t, map[string]interface{}{}),
 						},
 					},
 				}),
@@ -291,7 +281,7 @@ func TestParseRawOplogEntry(t *testing.T) {
 
 	for testName, test := range tests {
 		t.Run(testName, func(t *testing.T) {
-			got := (&Tailer{Denylist: &sync.Map{}}).parseRawOplogEntry(test.in, nil)
+			got := (&Tailer{Denylist: &sync.Map{}}).parseRawOplogEntry(&test.in, nil)
 
 			if diff := pretty.Compare(parseEntry(t, got), parseEntry(t, test.want)); diff != "" {
 				t.Errorf("Got incorrect result (-got +want)\n%s", diff)

--- a/lib/oplog/tail_test.go
+++ b/lib/oplog/tail_test.go
@@ -142,7 +142,7 @@ func TestParseRawOplogEntry(t *testing.T) {
 				Operation: "u",
 				Namespace: "foo.Bar",
 				Doc:       mustRaw(t, map[string]interface{}{"new": "data"}),
-				Update:    rawOplogEntryID{ID: "updateid"},
+				Update:    rawBson(t, map[string]interface{}{"_id": "updateid"}),
 			},
 			want: []oplogEntry{{
 				Timestamp:  primitive.Timestamp{T: 1234},
@@ -200,9 +200,11 @@ func TestParseRawOplogEntry(t *testing.T) {
 											"_id": "id1",
 											"foo": "baz",
 										}),
+										Update: mustRaw(t, map[string]interface{}{}),
 									},
 								},
 							}),
+							Update: mustRaw(t, map[string]interface{}{}),
 						},
 						{
 							Operation: "i",
@@ -211,6 +213,7 @@ func TestParseRawOplogEntry(t *testing.T) {
 								"_id": "id1",
 								"foo": "bar",
 							}),
+							Update: mustRaw(t, map[string]interface{}{}),
 						},
 						{
 							Operation: "u",
@@ -218,7 +221,7 @@ func TestParseRawOplogEntry(t *testing.T) {
 							Doc: mustRaw(t, map[string]interface{}{
 								"foo": "quux",
 							}),
-							Update: rawOplogEntryID{"id2"},
+							Update: mustRaw(t, map[string]interface{}{"_id": "id2"}),
 						},
 						{
 							Operation: "d",
@@ -226,6 +229,7 @@ func TestParseRawOplogEntry(t *testing.T) {
 							Doc: mustRaw(t, map[string]interface{}{
 								"_id": "id3",
 							}),
+							Update: mustRaw(t, map[string]interface{}{}),
 						},
 					},
 				}),


### PR DESCRIPTION
Before entries can be masked out, or filtered by shard, an initial set of oplog entry metadata needs to be processed.  This is currently done via the rawOplogEntry type which is populated using bson.Unmarshal(), but this is much slower compared to accessing the necessary properties directly using bson methods.  Additionally, the namespace entry can be accessed before anything else, so that filtering can happen as far upstream as possible.

Benchmarking shows that small entries are 2x as fast, while the largest entries can be 100x faster.