### PR TITLE
Add metric for catchup failure and increase catchup time to 2 minutes

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 buildGoModule {
   pname = "oplogtoredis";
-  version = "3.8.0";
+  version = "3.8.1";
   src = builtins.path { path = ./.; };
 
   postInstall = ''

--- a/lib/config/main.go
+++ b/lib/config/main.go
@@ -16,8 +16,8 @@ type oplogtoredisConfiguration struct {
 	HTTPServerAddr                string        `default:"0.0.0.0:9000" envconfig:"HTTP_SERVER_ADDR"`
 	BufferSize                    int           `default:"10000" split_words:"true"`
 	TimestampFlushInterval        time.Duration `default:"1s" split_words:"true"`
-	MaxCatchUp                    time.Duration `default:"60s" split_words:"true"`
-	RedisDedupeExpiration         time.Duration `default:"120s" split_words:"true"`
+	MaxCatchUp                    time.Duration `default:"120s" split_words:"true"`
+	RedisDedupeExpiration         time.Duration `default:"150s" split_words:"true"`
 	RedisMetadataPrefix           string        `default:"oplogtoredis::" split_words:"true"`
 	MongoConnectTimeout           time.Duration `default:"10s" split_words:"true"`
 	MongoQueryTimeout             time.Duration `default:"5s" split_words:"true"`

--- a/lib/config/main_test.go
+++ b/lib/config/main_test.go
@@ -45,8 +45,8 @@ var envTests = map[string]struct {
 			HTTPServerAddr:         "0.0.0.0:9000",
 			BufferSize:             10000,
 			TimestampFlushInterval: time.Second,
-			MaxCatchUp:             time.Minute,
-			RedisDedupeExpiration:  2 * time.Minute,
+			MaxCatchUp:             2 * time.Minute,
+			RedisDedupeExpiration:  2 * time.Minute + 30 * time.Second,
 			RedisMetadataPrefix:    "oplogtoredis::",
 		},
 	},
@@ -109,42 +109,42 @@ func TestParseEnv(t *testing.T) {
 
 func checkConfigExpectation(t *testing.T, expectedConfig *oplogtoredisConfiguration) {
 	if expectedConfig.MongoURL != MongoURL() {
-		t.Errorf("Incorrect Mongo URL. Got \"%s\", Expected \"%s\"",
+		t.Errorf("Incorrect Mongo URL. Expected \"%s\", Got \"%s\"",
 			expectedConfig.MongoURL, MongoURL())
 	}
 
 	if expectedConfig.RedisURL != strings.Join(RedisURL()[:], "") {
-		t.Errorf("Incorrect Redis URL. Got \"%s\", Expected \"%s\"",
+		t.Errorf("Incorrect Redis URL. Expected \"%s\", Got \"%s\"",
 			expectedConfig.RedisURL, RedisURL())
 	}
 
 	if expectedConfig.HTTPServerAddr != HTTPServerAddr() {
-		t.Errorf("Incorrect HTTPServerAddr. Got \"%s\", Expected \"%s\"",
+		t.Errorf("Incorrect HTTPServerAddr. Expected \"%s\", Got \"%s\"",
 			expectedConfig.HTTPServerAddr, HTTPServerAddr())
 	}
 
 	if expectedConfig.BufferSize != BufferSize() {
-		t.Errorf("Incorrect BufferSize. Got %d, Expected %d",
+		t.Errorf("Incorrect BufferSize. Expected %d, Got %d",
 			expectedConfig.BufferSize, BufferSize())
 	}
 
 	if expectedConfig.TimestampFlushInterval != TimestampFlushInterval() {
-		t.Errorf("Incorrect TimestampFlushInterval. Got %d, Expected %d",
+		t.Errorf("Incorrect TimestampFlushInterval. Expected %d, Got %d",
 			expectedConfig.TimestampFlushInterval, TimestampFlushInterval())
 	}
 
 	if expectedConfig.MaxCatchUp != MaxCatchUp() {
-		t.Errorf("Incorrect MaxCatchUp. Got %d, Expected %d",
+		t.Errorf("Incorrect MaxCatchUp. Expected %d, Got %d",
 			expectedConfig.MaxCatchUp, MaxCatchUp())
 	}
 
 	if expectedConfig.RedisDedupeExpiration != RedisDedupeExpiration() {
-		t.Errorf("Incorrect RedisDedupeExpiration. Got %d, Expected %d",
+		t.Errorf("Incorrect RedisDedupeExpiration. Expected %d, Got %d",
 			expectedConfig.RedisDedupeExpiration, RedisDedupeExpiration())
 	}
 
 	if expectedConfig.RedisMetadataPrefix != RedisMetadataPrefix() {
-		t.Errorf("Incorrect RedisMetadataPrefix. Got \"%s\", Expected \"%s\"",
+		t.Errorf("Incorrect RedisMetadataPrefix. Expected \"%s\", Got \"%s\"",
 			expectedConfig.RedisMetadataPrefix, RedisMetadataPrefix())
 	}
 }


### PR DESCRIPTION
Previously the max catchup time default was 1 minute, which wasn't always enough to recover from a pod restart.  This
1. doubles the time to 2 minutes 
2. and also increases the dedup key TTL from 2m to 2.5m to allow for covering the catchup time without greatly increasing the number of keys (25% increase in total dedup keys, same create/expire rate).
3. Also added is `resume_failed` metric that increments each time it cannot catchup from where it left off.
4. Logging is also improved with the addition of last processed age in seconds.