### PR TITLE
Clean shutdown

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 buildGoModule {
   pname = "oplogtoredis";
-  version = "3.8.1";
+  version = "3.8.2";
   src = builtins.path { path = ./.; };
 
   postInstall = ''


### PR DESCRIPTION
Oplogtoredis already captured the SIGINT signal, but this adds SIGTERM as well, which is what k8s sends for termination of a pod.  This allows for graceful and clean shutdown.  Also corrects a panic from the HTTP server exit that was interrupting the clean shutdown process.  Tested locally and confirmed shutdown is working as expected.