### PR TITLE
Add label to staleness metrics to distinguish published vs duplicate entries

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 buildGoModule {
   pname = "oplogtoredis";
-  version = "3.8.2";
+  version = "3.8.3";
   src = builtins.path { path = ./.; };
 
   postInstall = ''

--- a/lib/redispub/publisher.go
+++ b/lib/redispub/publisher.go
@@ -39,7 +39,7 @@ var publishDedupe = redis.NewScript(`
 		return true
 	end
 
-	return false
+	return true
 `)
 
 var metricSentMessages = promauto.NewCounterVec(prometheus.CounterOpts{

--- a/lib/redispub/publisher.go
+++ b/lib/redispub/publisher.go
@@ -182,8 +182,8 @@ func publishSingleMessage(p *Publication, client redis.UniversalClient, prefix s
 	start := time.Now()
 	ordinalStr := strconv.Itoa(ordinal)
 	staleness := float64(time.Since(time.Unix(int64(p.OplogTimestamp.T), 0)).Seconds())
-
-	written, err := publishDedupe.Run(
+	written := true
+	_, err := publishDedupe.Run(
 		context.Background(),
 		client,
 		[]string{
@@ -200,7 +200,7 @@ func publishSingleMessage(p *Publication, client redis.UniversalClient, prefix s
 		dedupeExpirationSeconds,       // ARGV[1], expiration time
 		p.Msg,                         // ARGV[2], message
 		strings.Join(p.Channels, "$"), // ARGV[3], channels
-	).Bool()
+	).Result()
 
 	var status string
 	if written {

--- a/lib/redispub/publisher.go
+++ b/lib/redispub/publisher.go
@@ -36,9 +36,10 @@ var publishDedupe = redis.NewScript(`
 		for w in string.gmatch(ARGV[3], "([^$]+)") do
 			redis.call("PUBLISH", w, ARGV[2])
 		end
+		return true
 	end
 
-	return true
+	return false
 `)
 
 var metricSentMessages = promauto.NewCounterVec(prometheus.CounterOpts{

--- a/lib/redispub/publisher.go
+++ b/lib/redispub/publisher.go
@@ -29,7 +29,7 @@ type PublishOpts struct {
 
 // This script checks whether KEYS[1] is set. If it is, it does nothing. It not,
 // it sets the key, using ARGV[1] as the expiration, and then publishes the
-// message ARGV[2] to channels ARGV[3] and ARGV[4]. Returns true if published.
+// message ARGV[2] to channels ARGV[3] and ARGV[4]. Returns 2 if published.
 var publishDedupe = redis.NewScript(`
 	local res = 1
 	if redis.call("GET", KEYS[1]) == false then

--- a/lib/redispub/publisher.go
+++ b/lib/redispub/publisher.go
@@ -200,10 +200,10 @@ func publishSingleMessage(p *Publication, client redis.UniversalClient, prefix s
 		dedupeExpirationSeconds,       // ARGV[1], expiration time
 		p.Msg,                         // ARGV[2], message
 		strings.Join(p.Channels, "$"), // ARGV[3], channels
-	).Result()
+	).Bool()
 
 	var status string
-	if written.(bool) {
+	if written {
 		status = "published"
 	} else {
 		status = "duplicate"

--- a/lib/redispub/publisher.go
+++ b/lib/redispub/publisher.go
@@ -31,7 +31,7 @@ type PublishOpts struct {
 // it sets the key, using ARGV[1] as the expiration, and then publishes the
 // message ARGV[2] to channels ARGV[3] and ARGV[4]. Returns true if published.
 var publishDedupe = redis.NewScript(`
-	res = false
+	local res = false
 	if redis.call("GET", KEYS[1]) == false then
 		redis.call("SETEX", KEYS[1], ARGV[1], 1)
 		for w in string.gmatch(ARGV[3], "([^$]+)") do

--- a/lib/redispub/publisher.go
+++ b/lib/redispub/publisher.go
@@ -31,15 +31,16 @@ type PublishOpts struct {
 // it sets the key, using ARGV[1] as the expiration, and then publishes the
 // message ARGV[2] to channels ARGV[3] and ARGV[4]. Returns true if published.
 var publishDedupe = redis.NewScript(`
+	res = false
 	if redis.call("GET", KEYS[1]) == false then
 		redis.call("SETEX", KEYS[1], ARGV[1], 1)
 		for w in string.gmatch(ARGV[3], "([^$]+)") do
 			redis.call("PUBLISH", w, ARGV[2])
 		end
-		return true
+		res = true
 	end
 
-	return true
+	return res
 `)
 
 var metricSentMessages = promauto.NewCounterVec(prometheus.CounterOpts{

--- a/lib/redispub/publisher.go
+++ b/lib/redispub/publisher.go
@@ -200,7 +200,7 @@ func publishSingleMessage(p *Publication, client redis.UniversalClient, prefix s
 		dedupeExpirationSeconds,       // ARGV[1], expiration time
 		p.Msg,                         // ARGV[2], message
 		strings.Join(p.Channels, "$"), // ARGV[3], channels
-	).Result()
+	).Bool()
 
 	metricLastOplogEntryStaleness.WithLabelValues(ordinalStr).Set(staleness)
 	metricOplogEntryStaleness.WithLabelValues(ordinalStr).Observe(staleness)


### PR DESCRIPTION
Oplogtoredis runs two replicas in parallel which both write to redis, with dedup being done by a lua script.  However, both of these replicas report the latency in time to reach redis, regardless of whether it was the first to reach redis or not.  This means that is one replica is lagging behind, it will report larger latency values than what’s actually reaching redis, and we don’t have a way to filter these since they will be reported at a later time than the earlier successful write from the other replica.

This adds a return value to the dedup script and uses it as a label for the latency metrics.

Note: for some reason returning true/false from the lua script was causing the performance and fault_injection tests to fail (after an extra long time).  Switching to int, returning 1 or 2, worked. Testing showed that returning false was causing issues, and a search found [this](https://stackoverflow.com/questions/75403292/lua-script-return-false-is-giving-error-redis-nil-during-the-evalsha) which seems to align with this issue, where the lua script returning false is treated as an error, which then caused OTR to retry (until the dedupe token expired).  I [opened an issue with go-redis](https://github.com/redis/go-redis/issues/3246).