### PR TITLE
Downgrade benign error log to info

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 buildGoModule {
   pname = "oplogtoredis";
-  version = "3.8.5";
+  version = "3.8.4";
   src = builtins.path { path = ./.; };
 
   postInstall = ''

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 buildGoModule {
   pname = "oplogtoredis";
-  version = "3.8.4";
+  version = "3.8.5";
   src = builtins.path { path = ./.; };
 
   postInstall = ''

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 buildGoModule {
   pname = "oplogtoredis";
-  version = "3.8.3";
+  version = "3.8.4";
   src = builtins.path { path = ./.; };
 
   postInstall = ''

--- a/lib/oplog/tail.go
+++ b/lib/oplog/tail.go
@@ -604,7 +604,7 @@ func (tailer *Tailer) parseRawOplogEntry(entry *rawOplogEntry, txIdx *uint) []op
 
 		applyOpsLookup, err := entry.Doc.LookupErr("applyOps")
 		if err != nil {
-			log.Log.Errorf("Looking up transaction data: %v", err)
+			log.Log.Errorf("Looking up transaction data: %v, namespace: %v", err, entry.Namespace)
 			return nil
 		}
 

--- a/lib/oplog/tail.go
+++ b/lib/oplog/tail.go
@@ -604,7 +604,16 @@ func (tailer *Tailer) parseRawOplogEntry(entry *rawOplogEntry, txIdx *uint) []op
 
 		applyOpsLookup, err := entry.Doc.LookupErr("applyOps")
 		if err != nil {
-			log.Log.Errorf("Looking up transaction data: %v, namespace: %v", err, entry.Namespace)
+			list, errList := entry.Doc.Elements()
+			if err != nil {
+				log.Log.Errorf("Looking up transaction data: %v, doc error: %v", err, errList)
+				return nil
+			}
+			keys := []string{}
+			for _, rawElem := range list {
+				keys = append(keys, rawElem.Key())
+			}
+			log.Log.Errorf("Looking up transaction data: %v, keys: %v", err, strings.Join(keys, ", "))
 			return nil
 		}
 

--- a/lib/oplog/tail.go
+++ b/lib/oplog/tail.go
@@ -606,14 +606,14 @@ func (tailer *Tailer) parseRawOplogEntry(entry *rawOplogEntry, txIdx *uint) []op
 		if err != nil {
 			list, errList := entry.Doc.Elements()
 			if errList != nil {
-				log.Log.Infof("applyOps key not found in command entry: %v, doc error: %v", err, errList)
+				log.Log.Debugf("applyOps key not found in command entry: %v, doc error: %v", err, errList)
 				return nil
 			}
 			keys := []string{}
 			for _, rawElem := range list {
 				keys = append(keys, rawElem.Key())
 			}
-			log.Log.Infof("applyOps key not found in command entry, ignoring. Keys: %v", strings.Join(keys, ", "))
+			log.Log.Debugf("applyOps key not found in command entry, ignoring. Keys: %v", strings.Join(keys, ", "))
 			return nil
 		}
 

--- a/lib/oplog/tail.go
+++ b/lib/oplog/tail.go
@@ -605,7 +605,7 @@ func (tailer *Tailer) parseRawOplogEntry(entry *rawOplogEntry, txIdx *uint) []op
 		applyOpsLookup, err := entry.Doc.LookupErr("applyOps")
 		if err != nil {
 			list, errList := entry.Doc.Elements()
-			if err != nil {
+			if errList != nil {
 				log.Log.Errorf("Looking up transaction data: %v, doc error: %v", err, errList)
 				return nil
 			}

--- a/lib/oplog/tail.go
+++ b/lib/oplog/tail.go
@@ -606,14 +606,14 @@ func (tailer *Tailer) parseRawOplogEntry(entry *rawOplogEntry, txIdx *uint) []op
 		if err != nil {
 			list, errList := entry.Doc.Elements()
 			if errList != nil {
-				log.Log.Errorf("Looking up transaction data: %v, doc error: %v", err, errList)
+				log.Log.Infof("applyOps key not found in command entry: %v, doc error: %v", err, errList)
 				return nil
 			}
 			keys := []string{}
 			for _, rawElem := range list {
 				keys = append(keys, rawElem.Key())
 			}
-			log.Log.Errorf("Looking up transaction data: %v, keys: %v", err, strings.Join(keys, ", "))
+			log.Log.Infof("applyOps key not found in command entry, ignoring. Keys: %v", strings.Join(keys, ", "))
 			return nil
 		}
 


### PR DESCRIPTION
For commands that aren't transactions, we can safely ignore the missing applyOps key, since that key will only be there when it is a transaction.  All other commands that do not include the applyOps key apply only to the admin db, so there is no need to further process these.