### PR TITLE
OplogToRedis: Better Logging for Denylist Failures

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 buildGoModule {
   pname = "oplogtoredis";
-  version = "3.8.4";
+  version = "3.8.5";
   src = builtins.path { path = ./.; };
 
   postInstall = ''

--- a/lib/denylist/http.go
+++ b/lib/denylist/http.go
@@ -104,7 +104,8 @@ func createDenylistEntry(response http.ResponseWriter, request *http.Request, de
 	metricFilterEnabled.WithLabelValues(id).Set(1)
 	err := syncer.StoreDenylistEntry(denylist, id)
 	if err != nil {
-		http.Error(response, "failed to persist removal of denylist entry", http.StatusInternalServerError)
+		log.Log.Warnw("Failed to persist creation of denylist entry", "id", id, "error", err.Error())
+		http.Error(response, "failed to persist creation of denylist entry", http.StatusInternalServerError)
 		return
 	}
 
@@ -129,6 +130,7 @@ func deleteDenylistEntry(response http.ResponseWriter, request *http.Request, de
 	metricFilterEnabled.WithLabelValues(id).Set(0)
 	err := syncer.DeleteDenylistEntry(denylist, id)
 	if err != nil {
+		log.Log.Warnw("Failed to persist removal of denylist entry", "id", id, "error", err.Error())
 		http.Error(response, "failed to persist removal of denylist entry", http.StatusInternalServerError)
 		return
 	}


### PR DESCRIPTION
## Summary
When the denylist fails to update due to a database error, the error is now logged.

## Jira Task
- [X] No ticket needed (check only if level of impact is No-op)

## Level of Impact
Please select exactly one option. To change the level of impact, first unselect the current level of impact and then select the new level of impact.

- [ ] 1 - High
- [ ] 2 - Medium
- [ ] 3 - Low
- [X] 4 - No-op

## Impact Analysis
This is a logging only change, and it's not an error level log.

## Release Notes
none

## Release Change Category
Please select exactly one option. To change the release change category, first unselect the current category and then select the new one.

- [ ] 1 - Internal Only (Non Customer Facing)
- [ ] 2 - Bug Fix (Customer Facing)
- [ ] 3 - New Feature
- [ ] 4 - Feature Enhancement
- [ ] 5 - Feature Deprecated
- [X] 6 - Release Change Category Not Needed

## Feature Flags
none

## Test Plan
n/a

## Checklist
Check each when they are done or confirmed to not apply. If something here isn't checked, this isn't ready to be merged. Seriously. You are making your colleagues lives a lot easier by doing this consistently. Be a good Tulipian.

- [X] [Test Plan Fully Executed](https://tulipmfg.atlassian.net/wiki/spaces/PLAT/pages/2352742443/Test+Plan)
- [ ] [Cypress Tests](https://tulipmfg.atlassian.net/wiki/spaces/PLAT/pages/2352742443/Test+Plan)
- [ ] [Does not require security review or security review complete](https://tulipmfg.atlassian.net/wiki/spaces/PLAT/pages/8093713/Security+Review+process)

For more information on the requirements for every pull request, see [Development Definition of Done](https://tulipmfg.atlassian.net/wiki/spaces/PLAT/pages/2352382014/Development+Definition+of+Done).
