### PR TITLE
Log and return error for delete denylist that doesn't exist

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -17,7 +17,7 @@ jobs:
       - name: run nix build
         run: nix build
   lint_and_units:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
@@ -33,35 +33,35 @@ jobs:
       - name: run unit tests
         run: ./scripts/runUnitTests.sh
   acceptance:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
       - name: run acceptance tests
         run: ./scripts/runIntegrationAcceptance.sh
   performance:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
       - name: run performance tests
         run: ./scripts/runIntegrationPerformance.sh
   fault_injection:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
       - name: run fault injection tests
         run: ./scripts/runIntegrationFaultInjection.sh
   meteor:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
       - name: run meteor tests
         run: ./scripts/runIntegrationMeteor.sh
   blackbox:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 buildGoModule {
   pname = "oplogtoredis";
-  version = "3.8.5";
+  version = "3.8.6";
   src = builtins.path { path = ./.; };
 
   postInstall = ''

--- a/lib/denylist/http.go
+++ b/lib/denylist/http.go
@@ -96,7 +96,7 @@ func createDenylistEntry(response http.ResponseWriter, request *http.Request, de
 	}
 	_, exists := denylist.Load(id)
 	if exists {
-		log.Log.Infow("Denylist PUT: Create called for denylist entry that already exists", "id", id)
+		log.Log.Infow("Denylist PUT: Create called for entry that already exists", "id", id)
 		response.WriteHeader(http.StatusNoContent)
 		return
 	}

--- a/lib/denylist/http.go
+++ b/lib/denylist/http.go
@@ -121,7 +121,7 @@ func deleteDenylistEntry(response http.ResponseWriter, request *http.Request, de
 	}
 	_, exists := denylist.Load(id)
 	if !exists {
-		log.Log.Warnw("Attempted removal of non-existant denylist entry", "id", id, "error", err.Error())
+		log.Log.Warnw("Attempted removal of non-existent denylist entry", "id", id)
 		response.WriteHeader(http.StatusNotFound)
 		return
 	}

--- a/lib/denylist/http.go
+++ b/lib/denylist/http.go
@@ -121,7 +121,8 @@ func deleteDenylistEntry(response http.ResponseWriter, request *http.Request, de
 	}
 	_, exists := denylist.Load(id)
 	if !exists {
-		response.WriteHeader(http.StatusNoContent)
+		log.Log.Warnw("Attempted removal of non-existant denylist entry", "id", id, "error", err.Error())
+		response.WriteHeader(http.StatusNotFound)
 		return
 	}
 

--- a/lib/denylist/http.go
+++ b/lib/denylist/http.go
@@ -96,7 +96,7 @@ func createDenylistEntry(response http.ResponseWriter, request *http.Request, de
 	}
 	_, exists := denylist.Load(id)
 	if exists {
-		log.Log.Infow("PUT: Create called for denylist entry that already exists", "id", id)
+		log.Log.Infow("Denylist PUT: Create called for denylist entry that already exists", "id", id)
 		response.WriteHeader(http.StatusNoContent)
 		return
 	}

--- a/lib/denylist/http.go
+++ b/lib/denylist/http.go
@@ -90,21 +90,23 @@ func getDenylistEntry(response http.ResponseWriter, request *http.Request, denyl
 func createDenylistEntry(response http.ResponseWriter, request *http.Request, denylist *sync.Map, syncer *Syncer) {
 	id := request.URL.Path
 	if strings.Contains(id, "/") {
+		log.Log.Warnw("Denylist PUT: entry includes '/'", "id", id)
 		http.Error(response, http.StatusText(http.StatusNotFound), http.StatusNotFound)
 		return
 	}
 	_, exists := denylist.Load(id)
 	if exists {
+		log.Log.Infow("PUT: Create called for denylist entry that already exists", "id", id)
 		response.WriteHeader(http.StatusNoContent)
 		return
 	}
 
 	denylist.Store(id, true)
-	log.Log.Infow("Created denylist entry", "id", id)
+	log.Log.Infow("Denylist PUT: Created entry", "id", id)
 	metricFilterEnabled.WithLabelValues(id).Set(1)
 	err := syncer.StoreDenylistEntry(denylist, id)
 	if err != nil {
-		log.Log.Warnw("Failed to persist creation of denylist entry", "id", id, "error", err.Error())
+		log.Log.Warnw("Denylist PUT: Failed to persist creation of entry", "id", id, "error", err.Error())
 		http.Error(response, "failed to persist creation of denylist entry", http.StatusInternalServerError)
 		return
 	}
@@ -116,22 +118,23 @@ func createDenylistEntry(response http.ResponseWriter, request *http.Request, de
 func deleteDenylistEntry(response http.ResponseWriter, request *http.Request, denylist *sync.Map, syncer *Syncer) {
 	id := request.URL.Path
 	if strings.Contains(id, "/") {
+		log.Log.Warnw("Denylist DELETE: entry includes '/'", "id", id)
 		http.Error(response, http.StatusText(http.StatusNotFound), http.StatusNotFound)
 		return
 	}
 	_, exists := denylist.Load(id)
 	if !exists {
-		log.Log.Warnw("Attempted removal of non-existent denylist entry", "id", id)
+		log.Log.Warnw("Denylist DELETE: non-existent entry", "id", id)
 		response.WriteHeader(http.StatusNotFound)
 		return
 	}
 
 	denylist.Delete(id)
-	log.Log.Infow("Deleted denylist entry", "id", id)
+	log.Log.Infow("Denylist DELETE: removed entry", "id", id)
 	metricFilterEnabled.WithLabelValues(id).Set(0)
 	err := syncer.DeleteDenylistEntry(denylist, id)
 	if err != nil {
-		log.Log.Warnw("Failed to persist removal of denylist entry", "id", id, "error", err.Error())
+		log.Log.Warnw("Denylist DELETE: Failed to persist removal of entry", "id", id, "error", err.Error())
 		http.Error(response, "failed to persist removal of denylist entry", http.StatusInternalServerError)
 		return
 	}


### PR DESCRIPTION
When an item in the denylist is deleted, the former behavior didn't provide any feedback as to whether it existed or not.  This PR adds a log warning and returns 404 for a delete attempt on an entry not in the denylist.

Additionally, the acceptance test runner was updated to ubuntu 24.04 because 20.04 was deprecated on 4/15.