### PR TITLE
Improve precision of staleness metrics using oplog entry wall time

### DIFF
--- a/lib/oplog/oplogEntry.go
+++ b/lib/oplog/oplogEntry.go
@@ -1,6 +1,8 @@
 package oplog
 
 import (
+	"time"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/tulip/oplogtoredis/lib/log"
@@ -27,6 +29,7 @@ var metricUnprocessableChangedFields = promauto.NewCounter(prometheus.CounterOpt
 type oplogEntry struct {
 	DocID      interface{}
 	Timestamp  primitive.Timestamp
+	WallTime   time.Time
 	Data       bson.Raw
 	Operation  string
 	Namespace  string
@@ -137,6 +140,7 @@ func (op *oplogEntry) ChangedFields() ([]string, error) {
 type oplogEntryLogData struct {
 	DocID      interface{}         `json:"docID"`
 	Timestamp  primitive.Timestamp `json:"timestamp"`
+	WallTime   time.Time           `json:"walltime"`
 	Operation  string              `json:"operation"`
 	Namespace  string              `json:"namespace"`
 	Database   string              `json:"database"`
@@ -149,6 +153,7 @@ func (op *oplogEntry) LogData() oplogEntryLogData {
 	return oplogEntryLogData{
 		DocID:      op.DocID,
 		Timestamp:  op.Timestamp,
+		WallTime:   op.WallTime,
 		Operation:  op.Operation,
 		Namespace:  op.Namespace,
 		Database:   op.Database,

--- a/lib/oplog/processor.go
+++ b/lib/oplog/processor.go
@@ -109,6 +109,7 @@ func processOplogEntry(op *oplogEntry) (*redispub.Publication, error) {
 		},
 		Msg:            msgJSON,
 		OplogTimestamp: op.Timestamp,
+		WallTime:       op.WallTime,
 
 		TxIdx:          op.TxIdx,
 		ParallelismKey: int(hashInt),

--- a/lib/oplog/processor_test.go
+++ b/lib/oplog/processor_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"sort"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"go.mongodb.org/mongo-driver/bson/primitive"
@@ -31,6 +32,7 @@ func TestProcessOplogEntry(t *testing.T) {
 		Channels       []string
 		Msg            decodedPublicationMessage
 		OplogTimestamp primitive.Timestamp
+		WallTime       time.Time
 		ParallelismKey int
 	}
 
@@ -60,6 +62,7 @@ func TestProcessOplogEntry(t *testing.T) {
 					"some": "field",
 				}),
 				Timestamp: primitive.Timestamp{T: 1234},
+				WallTime:  time.Unix(1234, 0).UTC(),
 			},
 			want: &decodedPublication{
 				Channels: []string{"foo.bar", "foo.bar::someid"},
@@ -71,6 +74,7 @@ func TestProcessOplogEntry(t *testing.T) {
 					Fields: []string{"some"},
 				},
 				OplogTimestamp: primitive.Timestamp{T: 1234},
+				WallTime:       time.Unix(1234, 0).UTC(),
 				ParallelismKey: fooHash,
 			},
 		},
@@ -86,6 +90,7 @@ func TestProcessOplogEntry(t *testing.T) {
 					"new":  "field",
 				}),
 				Timestamp: primitive.Timestamp{T: 1234},
+				WallTime:  time.Unix(1234, 0).UTC(),
 			},
 			want: &decodedPublication{
 				Channels: []string{"foo.bar", "foo.bar::someid"},
@@ -97,6 +102,7 @@ func TestProcessOplogEntry(t *testing.T) {
 					Fields: []string{"some", "new"},
 				},
 				OplogTimestamp: primitive.Timestamp{T: 1234},
+				WallTime:       time.Unix(1234, 0).UTC(),
 				ParallelismKey: fooHash,
 			},
 		},
@@ -118,6 +124,7 @@ func TestProcessOplogEntry(t *testing.T) {
 					},
 				}),
 				Timestamp: primitive.Timestamp{T: 1234},
+				WallTime:  time.Unix(1234, 0).UTC(),
 			},
 			want: &decodedPublication{
 				Channels: []string{"foo.bar", "foo.bar::someid"},
@@ -129,6 +136,7 @@ func TestProcessOplogEntry(t *testing.T) {
 					Fields: []string{"a", "b", "c"},
 				},
 				OplogTimestamp: primitive.Timestamp{T: 1234},
+				WallTime:       time.Unix(1234, 0).UTC(),
 				ParallelismKey: fooHash,
 			},
 		},
@@ -141,6 +149,7 @@ func TestProcessOplogEntry(t *testing.T) {
 				Collection: "bar",
 				Data:       rawBson(t, bson.M{}),
 				Timestamp:  primitive.Timestamp{T: 1234},
+				WallTime:   time.Unix(1234, 0).UTC(),
 			},
 			want: &decodedPublication{
 				Channels: []string{"foo.bar", "foo.bar::someid"},
@@ -152,6 +161,7 @@ func TestProcessOplogEntry(t *testing.T) {
 					Fields: []string{},
 				},
 				OplogTimestamp: primitive.Timestamp{T: 1234},
+				WallTime:       time.Unix(1234, 0).UTC(),
 				ParallelismKey: fooHash,
 			},
 		},
@@ -166,6 +176,7 @@ func TestProcessOplogEntry(t *testing.T) {
 					"some": "field",
 				}),
 				Timestamp: primitive.Timestamp{T: 1234},
+				WallTime:  time.Unix(1234, 0).UTC(),
 			},
 			want: &decodedPublication{
 				Channels: []string{"foo.bar", "foo.bar::deadbeefdeadbeefdeadbeef"},
@@ -180,6 +191,7 @@ func TestProcessOplogEntry(t *testing.T) {
 					Fields: []string{"some"},
 				},
 				OplogTimestamp: primitive.Timestamp{T: 1234},
+				WallTime:       time.Unix(1234, 0).UTC(),
 				ParallelismKey: fooHash,
 			},
 		},
@@ -194,6 +206,7 @@ func TestProcessOplogEntry(t *testing.T) {
 					"some": "field",
 				}),
 				Timestamp: primitive.Timestamp{T: 1234},
+				WallTime:  time.Unix(1234, 0).UTC(),
 			},
 			wantError: ErrUnsupportedDocIDType,
 			want:      nil,
@@ -209,6 +222,7 @@ func TestProcessOplogEntry(t *testing.T) {
 					"some": "field",
 				}),
 				Timestamp: primitive.Timestamp{T: 1234},
+				WallTime:  time.Unix(1234, 0).UTC(),
 			},
 			want: nil,
 		},
@@ -230,6 +244,7 @@ func TestProcessOplogEntry(t *testing.T) {
 					},
 				}),
 				Timestamp: primitive.Timestamp{T: 1636616135},
+				WallTime:  time.Unix(1234, 0).UTC(),
 			},
 			want: nil,
 		},
@@ -254,6 +269,7 @@ func TestProcessOplogEntry(t *testing.T) {
 			Channels:       pub.Channels,
 			Msg:            msg,
 			OplogTimestamp: pub.OplogTimestamp,
+			WallTime:       pub.WallTime,
 			ParallelismKey: pub.ParallelismKey,
 		}
 	}

--- a/lib/oplog/tail_test.go
+++ b/lib/oplog/tail_test.go
@@ -112,12 +112,14 @@ func TestParseRawOplogEntry(t *testing.T) {
 		"Insert": {
 			in: rawOplogEntry{
 				Timestamp: primitive.Timestamp{T: 1234},
+				WallTime:  time.Unix(1234, 0).UTC(),
 				Operation: "i",
 				Namespace: "foo.Bar",
 				Doc:       rawBson(t, map[string]interface{}{"_id": "someid", "foo": "bar"}),
 			},
 			want: []oplogEntry{{
 				Timestamp:  primitive.Timestamp{T: 1234},
+				WallTime:   time.Unix(1234, 0).UTC(),
 				Operation:  "i",
 				Namespace:  "foo.Bar",
 				Data:       rawBson(t, map[string]interface{}{"_id": "someid", "foo": "bar"}),
@@ -129,6 +131,7 @@ func TestParseRawOplogEntry(t *testing.T) {
 		"Update": {
 			in: rawOplogEntry{
 				Timestamp: primitive.Timestamp{T: 1234},
+				WallTime:  time.Unix(1234, 0).UTC(),
 				Operation: "u",
 				Namespace: "foo.Bar",
 				Doc:       rawBson(t, map[string]interface{}{"new": "data"}),
@@ -136,6 +139,7 @@ func TestParseRawOplogEntry(t *testing.T) {
 			},
 			want: []oplogEntry{{
 				Timestamp:  primitive.Timestamp{T: 1234},
+				WallTime:   time.Unix(1234, 0).UTC(),
 				Operation:  "u",
 				Namespace:  "foo.Bar",
 				Data:       rawBson(t, map[string]interface{}{"new": "data"}),
@@ -147,12 +151,14 @@ func TestParseRawOplogEntry(t *testing.T) {
 		"Remove": {
 			in: rawOplogEntry{
 				Timestamp: primitive.Timestamp{T: 1234},
+				WallTime:  time.Unix(1234, 0).UTC(),
 				Operation: "d",
 				Namespace: "foo.Bar",
 				Doc:       rawBson(t, map[string]interface{}{"_id": "someid"}),
 			},
 			want: []oplogEntry{{
 				Timestamp:  primitive.Timestamp{T: 1234},
+				WallTime:   time.Unix(1234, 0).UTC(),
 				Operation:  "d",
 				Namespace:  "foo.Bar",
 				Data:       rawBson(t, map[string]interface{}{"_id": "someid"}),
@@ -164,6 +170,7 @@ func TestParseRawOplogEntry(t *testing.T) {
 		"Command": {
 			in: rawOplogEntry{
 				Timestamp: primitive.Timestamp{T: 1234},
+				WallTime:  time.Unix(1234, 0).UTC(),
 				Operation: "c",
 				Namespace: "foo.$cmd",
 				Doc:       rawBson(t, map[string]interface{}{"drop": "Foo"}),
@@ -173,12 +180,14 @@ func TestParseRawOplogEntry(t *testing.T) {
 		"Transaction": {
 			in: rawOplogEntry{
 				Timestamp: primitive.Timestamp{T: 1234},
+				WallTime:  time.Unix(1234, 0).UTC(),
 				Operation: "c",
 				Namespace: "admin.$cmd",
 				Doc: rawBson(t, map[string]interface{}{
 					"applyOps": []rawOplogEntry{
 						{
 							Timestamp: primitive.Timestamp{T: 1234},
+							WallTime:  time.Unix(1234, 0).UTC(),
 							Operation: "c",
 							Namespace: "admin.$cmd",
 							Doc: rawBson(t, map[string]interface{}{
@@ -228,6 +237,7 @@ func TestParseRawOplogEntry(t *testing.T) {
 				{
 					DocID:      "id1",
 					Timestamp:  primitive.Timestamp{T: 1234},
+					WallTime:   time.Unix(1234, 0).UTC(),
 					Operation:  "i",
 					Namespace:  "foo.Bar",
 					Database:   "foo",
@@ -241,6 +251,7 @@ func TestParseRawOplogEntry(t *testing.T) {
 				{
 					DocID:      "id1",
 					Timestamp:  primitive.Timestamp{T: 1234},
+					WallTime:   time.Unix(1234, 0).UTC(),
 					Operation:  "i",
 					Namespace:  "foo.Bar",
 					Database:   "foo",
@@ -254,6 +265,7 @@ func TestParseRawOplogEntry(t *testing.T) {
 				{
 					DocID:      "id2",
 					Timestamp:  primitive.Timestamp{T: 1234},
+					WallTime:   time.Unix(1234, 0).UTC(),
 					Operation:  "u",
 					Namespace:  "foo.Bar",
 					Database:   "foo",
@@ -266,6 +278,7 @@ func TestParseRawOplogEntry(t *testing.T) {
 				{
 					DocID:      "id3",
 					Timestamp:  primitive.Timestamp{T: 1234},
+					WallTime:   time.Unix(1234, 0).UTC(),
 					Operation:  "d",
 					Namespace:  "foo.Bar",
 					Database:   "foo",
@@ -293,6 +306,7 @@ func TestParseRawOplogEntry(t *testing.T) {
 type oplogEntryConverted struct {
 	DocID      interface{}
 	Timestamp  primitive.Timestamp
+	WallTime   time.Time
 	Data       map[string]interface{}
 	Operation  string
 	Namespace  string
@@ -313,6 +327,7 @@ func parseEntry(t *testing.T, op []oplogEntry) []oplogEntryConverted {
 		}
 		opc[i].DocID = op[i].DocID
 		opc[i].Timestamp = op[i].Timestamp
+		opc[i].WallTime = op[i].WallTime
 		opc[i].Data = data
 		opc[i].Operation = op[i].Operation
 		opc[i].Namespace = op[i].Namespace

--- a/lib/redispub/publication.go
+++ b/lib/redispub/publication.go
@@ -1,6 +1,8 @@
 package redispub
 
 import (
+	"time"
+
 	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
@@ -17,6 +19,9 @@ type Publication struct {
 	// a monotonically increasing timestamp *and* a unique identifier --
 	// see https://docs.mongodb.com/manual/reference/bson-types/#timestamps
 	OplogTimestamp primitive.Timestamp
+
+	// WallTime is the database server wall time of the oplog entry.
+	WallTime time.Time
 
 	// TxIdx is the index of the operation within a transaction. Used to supplement OplogTimestamp in a transaction.
 	TxIdx uint

--- a/lib/redispub/publisher.go
+++ b/lib/redispub/publisher.go
@@ -85,7 +85,7 @@ var metricOplogEntryStaleness = promauto.NewHistogramVec(prometheus.HistogramOpt
 	Subsystem: "redispub",
 	Name:      "entry_staleness_seconds",
 	Help:      "Histogram recording the difference between this server's clock and the timestamp of each processed oplog entry.",
-	Buckets:   []float64{0.1, 0.2, 0.5, 1, 2, 5, 10, 20, 50, 100},
+	Buckets:   []float64{0.01, 0.02, 0.05, 0.1, 0.2, 0.5, 1, 2, 3, 5, 7, 10, 20, 50, 100},
 }, []string{"ordinal", "status"})
 
 // PublishStream reads Publications from the given channel and publishes them


### PR DESCRIPTION
There are a handful of staleness metrics that compare the timestamp attached to oplog events with the current time in oplogtoredis. These originally used the oplog timestamp, since it was already included in parsed oplog entries, but this is not ideal for metrics since it only has resolution to the nearest second, with the rest of the timestamp bits dedicated to ordering instead.

With this change, we use the wall time from each oplog entry instead, which has resolution to the nearest millisecond.

Now that the metric is more precise, buckets needed to be updated to account for the increased precision. A set of buckets below 10ms has been added to reflect typical performance under minimal load. Extra buckets between 1-10s have also been added, since this area of latency is perceptually relevant for users expecting to see live changes in Meteor.

Unit tests have been updated to check that oplog timestamps are included in parsed entries, and existing acceptance tests verify that the oplog wall time parsing works with real entries. This change was also tested manually to ensure that the resulting metrics are more accurate and do not average out to ~0.5s staleness, which happened when the precision was only to the nearest second.