### PR TITLE
Upgrade Debian Docker image tags for dev and test containers

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 golang:1.17.0-buster
+FROM --platform=linux/amd64 golang:1.17.0-bullseye
 
 # This netcat installation is needed for the following wait-for.sh invocation
 RUN apt-get update && apt-get install -y netcat-openbsd

--- a/Dockerfile.integration
+++ b/Dockerfile.integration
@@ -1,6 +1,6 @@
 # expects build context of oplogtoredis
 
-FROM --platform=linux/amd64 golang:1.17.0-buster AS integration_base
+FROM --platform=linux/amd64 golang:1.17.0-bullseye AS integration_base
 
 ENV GO111MODULE on
 
@@ -39,7 +39,7 @@ RUN go test -c -o /test
 RUN go build -o /analyze analyzeBench.go
 
 
-FROM --platform=linux/amd64 debian:buster
+FROM --platform=linux/amd64 debian:bullseye
 COPY scripts/install-debian-mongo.sh ./install-debian-mongo.sh
 RUN apt-get update && apt-get install -y jq netcat && ./install-debian-mongo.sh
 RUN mkdir -p /integration/bin

--- a/blackbox-tests/Dockerfile.oplogtoredis-blackbox
+++ b/blackbox-tests/Dockerfile.oplogtoredis-blackbox
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 golang:1.17.0-buster
+FROM --platform=linux/amd64 golang:1.17.0-bullseye
 
 COPY scripts/install-debian-mongo.sh ./install-debian-mongo.sh
 RUN apt-get update && apt-get install -y netcat git libsasl2-dev && ./install-debian-mongo.sh

--- a/integration-tests/fault-injection/Dockerfile
+++ b/integration-tests/fault-injection/Dockerfile
@@ -1,6 +1,6 @@
 # This expects to be run with the root of the repo as the context directory
 
-FROM redis:6.0-buster
+FROM redis:6.0-bullseye
 
 # Install mongo, and musl (for oplogtoredis bin)
 COPY scripts/install-debian-mongo.sh ./install-debian-mongo.sh

--- a/integration-tests/fault-injection/harness/postgres.go
+++ b/integration-tests/fault-injection/harness/postgres.go
@@ -21,7 +21,7 @@ func runCommandWithLogs(name string, args ...string) {
 func StartPostgresServer() *PostgresServer {
 	runCommandWithLogs(
 		"pg_ctlcluster",
-		"11",
+		"13",
 		"main",
 		"start",
 	)
@@ -46,7 +46,7 @@ func StartPostgresServer() *PostgresServer {
 func (server *PostgresServer) Stop() {
 	runCommandWithLogs(
 		"pg_ctlcluster",
-		"11",
+		"13",
 		"main",
 		"stop",
 	)

--- a/integration-tests/fault-injection/harness/waitTCP.go
+++ b/integration-tests/fault-injection/harness/waitTCP.go
@@ -9,11 +9,11 @@ import (
 
 // waitTCP wait until the TCP service is accepting connections
 //
-// It times out and panics after 60 seconds.
+// It times out and panics after 30 seconds.
 func waitTCP(addr string) {
 	log.Printf("Waiting for TCP to be available at %s", addr)
 	// Try once a second to connect
-	for startTime := time.Now(); time.Since(startTime) < 10*time.Second; time.Sleep(time.Second) {
+	for startTime := time.Now(); time.Since(startTime) < 30*time.Second; time.Sleep(time.Second) {
 		conn, err := net.DialTimeout("tcp", addr, time.Second)
 
 		if err == nil {
@@ -36,11 +36,11 @@ func waitTCP(addr string) {
 
 // waitTCP wait until the TCP service is not accepting connections
 //
-// It times out and panics after 60 seconds.
+// It times out and panics after 30 seconds.
 func waitTCPDown(addr string) {
 	log.Printf("Waiting for TCP to be down at %s", addr)
 	// Try once a second to connect
-	for startTime := time.Now(); time.Since(startTime) < 10*time.Second; time.Sleep(time.Second) {
+	for startTime := time.Now(); time.Since(startTime) < 30*time.Second; time.Sleep(time.Second) {
 		conn, err := net.DialTimeout("tcp", addr, time.Second)
 
 		if err != nil {

--- a/scripts/install-debian-mongo.sh
+++ b/scripts/install-debian-mongo.sh
@@ -3,7 +3,7 @@ apt-get install -y wget gnupg
 
 wget -qO - https://pgp.mongodb.com/server-5.0.asc | gpg -o /usr/share/keyrings/mongodb-server-5.0.gpg --dearmor
 
-echo "deb [ signed-by=/usr/share/keyrings/mongodb-server-5.0.gpg ] https://repo.mongodb.org/apt/debian buster/mongodb-org/5.0 main" > /etc/apt/sources.list.d/mongodb-org-5.0.list
+echo "deb [ signed-by=/usr/share/keyrings/mongodb-server-5.0.gpg ] https://repo.mongodb.org/apt/debian bullseye/mongodb-org/5.0 main" > /etc/apt/sources.list.d/mongodb-org-5.0.list
 
 apt-get update
 apt-get install -y mongodb-org-server=5.0.19 mongodb-org-shell=5.0.19

--- a/testapp/Dockerfile
+++ b/testapp/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 node:14.18.3-buster
+FROM --platform=linux/amd64 node:14.21.3-bullseye
 
 # Install Meteor
 ENV METEOR_ALLOW_SUPERUSER=true
@@ -19,13 +19,13 @@ RUN meteor npm install && \
   cd /app/bundle/programs/server && \
   npm install
 
-FROM --platform=linux/amd64 node:14.18.3-buster-slim
+FROM --platform=linux/amd64 node:14.21.3-bullseye-slim
 
 # Install mongoDB client
 RUN apt-get update && apt-get install -y gnupg wget
 
 RUN wget -qO - https://pgp.mongodb.com/server-5.0.asc | gpg -o /usr/share/keyrings/mongodb-server-5.0.gpg --dearmor
-RUN echo "deb [ signed-by=/usr/share/keyrings/mongodb-server-5.0.gpg ] https://repo.mongodb.org/apt/debian buster/mongodb-org/5.0 main" > /etc/apt/sources.list.d/mongodb-org-5.0.list
+RUN echo "deb [ signed-by=/usr/share/keyrings/mongodb-server-5.0.gpg ] https://repo.mongodb.org/apt/debian bullseye/mongodb-org/5.0 main" > /etc/apt/sources.list.d/mongodb-org-5.0.list
 
 RUN apt-get update && apt-get install -y mongodb-org-shell netcat && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Upgrades the Docker image tags used for Debian-based images in development and test containers, since versions based on Debian "buster" no longer run due to offline repositories. As a stopgap, these are upgraded to the same tool versions but with images based on "bullseye", since there is a chain of incompatibilities related to an outdated MongoDB driver that makes further upgrades more difficult. Those will be addressed in future changes.