### PR TITLE
Denylist: Return 204 when non-existent entry is deleted from denylist

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 buildGoModule {
   pname = "oplogtoredis";
-  version = "3.8.8";
+  version = "3.8.9";
   src = builtins.path { path = ./.; };
 
   postInstall = ''

--- a/lib/denylist/http.go
+++ b/lib/denylist/http.go
@@ -124,8 +124,9 @@ func deleteDenylistEntry(response http.ResponseWriter, request *http.Request, de
 	}
 	_, exists := denylist.Load(id)
 	if !exists {
-		log.Log.Warnw("Denylist DELETE: non-existent entry", "id", id)
-		response.WriteHeader(http.StatusNotFound)
+		// Some deploy operations exit maintenance without entering it, so this needs to return a successful response code.
+		log.Log.Infow("Denylist DELETE: non-existent entry", "id", id)
+		response.WriteHeader(http.StatusNoContent)
 		return
 	}
 

--- a/lib/denylist/http.go
+++ b/lib/denylist/http.go
@@ -124,7 +124,7 @@ func deleteDenylistEntry(response http.ResponseWriter, request *http.Request, de
 	}
 	_, exists := denylist.Load(id)
 	if !exists {
-		// Deploy operations at Tulip require returning a successful response even if the entry is not present.
+		// Deploy operations at Tulip require returning a successful response code even if the entry is not present.
 		log.Log.Infow("Denylist DELETE: non-existent entry", "id", id)
 		response.WriteHeader(http.StatusNoContent)
 		return

--- a/lib/denylist/http.go
+++ b/lib/denylist/http.go
@@ -124,7 +124,7 @@ func deleteDenylistEntry(response http.ResponseWriter, request *http.Request, de
 	}
 	_, exists := denylist.Load(id)
 	if !exists {
-		// Some deploy operations exit maintenance without entering it, so this needs to return a successful response code.
+		// Deploy operations at Tulip require returning a successful response even if the entry is not present.
 		log.Log.Infow("Denylist DELETE: non-existent entry", "id", id)
 		response.WriteHeader(http.StatusNoContent)
 		return


### PR DESCRIPTION
When oplogtoredis receives an HTTP request to delete an entry from the denylist, if the entry doesn't exist, this [commit](https://github.com/tulip/oplogtoredis/commit/e1488dbf6af561a0a88c9ffe4a11271d23bb9fb3#diff-245563af9e34754739b12b294f3324c1d42c116ace7ce8735e21dfbc82d8e064) made it such that the response is a 404. However, this causes issues with deployment operations at Tulip, where it is valid to send a DELETE request for a denylist entry even if it was never added. This change returns to old behavior, where a 204 was returned in these cases.