### PR TITLE
Add redis batching

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 buildGoModule {
   pname = "oplogtoredis";
-  version = "3.8.11";
+  version = "3.9.0";
   src = builtins.path { path = ./.; };
 
   postInstall = ''

--- a/lib/config/main.go
+++ b/lib/config/main.go
@@ -31,6 +31,7 @@ type oplogtoredisConfiguration struct {
 	SentryRelease                 string        `default:"unknown" split_words:"true"`
 	ResumeTsReadRetries           int           `default:"5" split_words:"true"`
 	ResumeTsReadRetryDelay        time.Duration `default:"500ms" split_words:"true"`
+	RedisBatchSize		          int           `default:"25" split_words:"true"`
 }
 
 var globalConfig *oplogtoredisConfiguration
@@ -197,6 +198,12 @@ func ResumeTsReadRetries() int {
 // e.g., third attempt = 500ms * 3 = 1.5s delay before next attempt.
 func ResumeTsReadRetryDelay() time.Duration {
 	return globalConfig.ResumeTsReadRetryDelay
+}
+
+// RedisBatchSize is the maximum number of publications to batch per redis call
+// Defaults to 25.
+func RedisBatchSize() int {
+	return globalConfig.RedisBatchSize
 }
 
 // ParseEnv parses the current environment variables and updates the stored

--- a/lib/redispub/publisher.go
+++ b/lib/redispub/publisher.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/tulip/oplogtoredis/lib/config"
 	"github.com/tulip/oplogtoredis/lib/log"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 
@@ -135,7 +136,7 @@ func PublishStream(clients []redis.UniversalClient, in <-chan *Publication, opts
 		metricsSendSuccess[i] = metricSentMessages.WithLabelValues("sent", idx)
 	}
 
-	const batchSize = 25
+	const batchSize = config.RedisBatchSize()
 
 	for {
 		select {

--- a/lib/redispub/publisher.go
+++ b/lib/redispub/publisher.go
@@ -136,7 +136,7 @@ func PublishStream(clients []redis.UniversalClient, in <-chan *Publication, opts
 		metricsSendSuccess[i] = metricSentMessages.WithLabelValues("sent", idx)
 	}
 
-	const batchSize = config.RedisBatchSize()
+	var batchSize = config.RedisBatchSize()
 
 	for {
 		select {

--- a/lib/redispub/publisher.go
+++ b/lib/redispub/publisher.go
@@ -261,7 +261,13 @@ func publishBatch(batch []*Publication, client redis.UniversalClient, prefix str
 	args = append(args, dedupeExpirationSeconds)
 
 	for i, p := range batch {
+		if p == nil {
+			log.Log.Warn("got nil publication in batch")
+			continue
+		}
 		keys[i] = formatKey(p, prefix)
+		// The channels are a single string with channels separated by '$' characters.
+		// See the publishDedupe script for details.
 		args = append(args, p.Msg, strings.Join(p.Channels, "$"))
 	}
 

--- a/lib/redispub/publisher_test.go
+++ b/lib/redispub/publisher_test.go
@@ -173,12 +173,8 @@ func TestPeriodicallyUpdateTimestamp(t *testing.T) {
 }
 
 func TestEmptyPublicationBatch(t *testing.T) {
-	err := publishBatchWithRetries([]*Publication{}, 5, 1*time.Second, func(b []*Publication) error {
+	publishBatchWithRetries([]*Publication{}, 5, 1*time.Second, func(b []*Publication) error {
 		t.Error("Should not have been called")
 		return nil
 	})
-
-	if err == nil {
-		t.Error("Expected error")
-	}
 }

--- a/lib/redispub/publisher_test.go
+++ b/lib/redispub/publisher_test.go
@@ -173,8 +173,11 @@ func TestPeriodicallyUpdateTimestamp(t *testing.T) {
 }
 
 func TestEmptyPublicationBatch(t *testing.T) {
-	publishBatchWithRetries([]*Publication{}, 5, 1*time.Second, func(b []*Publication) error {
+	err := publishBatchWithRetries([]*Publication{}, 5, 1*time.Second, func(b []*Publication) error {
 		t.Error("Should not have been called")
 		return nil
 	})
+	if err != nil {
+		t.Errorf("Got unexpected error: %s", err)
+	}
 }


### PR DESCRIPTION
Adds batching for the publications written to the redis pubsub in order to decrease the number of round trips and improve overall throughput.  Testing found that the gains dropped off for batches above 25, so 25 was set as the default, although it is configurable with the REDIS_BATCH_SIZE environment variable.

Full load testing results with dual test on the effects on redis here: [PDF Summary](https://drive.google.com/file/d/1G7c8Hz-DXEayg9MXA20UglPSsWuE6hBw/view?usp=sharing), [Google Slides Overview](https://docs.google.com/presentation/d/1j22Zh_-YlS7zc9NhxqeYJdJmlJ7FL77NELYEQjDRH14/edit?usp=sharing), [Raw Text](https://drive.google.com/file/d/1hFbZyypTMv1k8v_8QPic2h02PiI10s05/view?usp=sharing)

Load test before/after screenshots:
<img width="877" height="625" alt="otr-current" src="https://github.com/user-attachments/assets/043b6eae-4d09-47e0-a2bd-b08c296777c7" />
<img width="842" height="636" alt="otr-batching" src="https://github.com/user-attachments/assets/63570aa8-9237-41c9-89f3-7326516473f3" />
