### PR TITLE
Add metric for oplog tailing startup failures

### DIFF
--- a/lib/oplog/tail.go
+++ b/lib/oplog/tail.go
@@ -112,7 +112,16 @@ var (
 		Help:      "Histogram recording the gap in time that a tailing resume had to catchup and whether it was successful or not.",
 		Buckets:   []float64{1, 2.5, 5, 10, 25, 50, 100, 250, 500, 1000},
 	}, []string{"status"})
+
+	metricTailFailedToStart = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: "otr",
+		Subsystem: "oplog",
+		Name:      "tail_failed_to_start",
+		Help:      "Number of times oplog tailing failed to start",
+	})
 )
+
+var errFailedToStart = errors.New("failed to start tailing")
 
 func init() {
 	prometheus.MustRegister(metricMaxOplogEntryByMinute)
@@ -138,11 +147,15 @@ func (tailer *Tailer) Tail(out []PublisherChannels, stop <-chan bool, readOrdina
 
 	for {
 		log.Log.Info("Starting oplog tailing")
-		tailer.tailOnce(out, childStopC, readOrdinal, readParallelism)
+		err := tailer.tailOnce(out, childStopC, readOrdinal, readParallelism)
 		log.Log.Info("Oplog tailing ended")
 
 		if wasStopped {
 			return
+		}
+
+		if errors.Is(err, errFailedToStart) {
+			metricTailFailedToStart.Inc()
 		}
 
 		log.Log.Errorw("Oplog tailing stopped prematurely. Waiting a second an then retrying.")
@@ -153,16 +166,16 @@ func (tailer *Tailer) Tail(out []PublisherChannels, stop <-chan bool, readOrdina
 // this accepts an array of PublisherChannels instances whose size is equal to the degree of write-parallelism.
 // Each incoming message will be routed to one of the PublisherChannels instances based on its parallelism key
 // (hash of the database name), then sent to every channel within that PublisherChannels instance.
-func (tailer *Tailer) tailOnce(out []PublisherChannels, stop <-chan bool, readOrdinal, readParallelism int) {
+func (tailer *Tailer) tailOnce(out []PublisherChannels, stop <-chan bool, readOrdinal, readParallelism int) error {
 	session, err := tailer.MongoClient.StartSession()
 	if err != nil {
 		log.Log.Errorw("Failed to start Mongo session", "error", err)
-		return
+		return errFailedToStart
 	}
 
 	oplogCollection := session.Client().Database("local").Collection("oplog.rs")
 
-	startTime := tailer.getStartTime(len(out)-1, func() (*primitive.Timestamp, error) {
+	startTime, startTimeErr := tailer.getStartTime(len(out)-1, func() (*primitive.Timestamp, error) {
 		// Get the timestamp of the last entry in the oplog (as a position to
 		// start from if we don't have a last-written timestamp from Redis)
 		var entry rawOplogEntry
@@ -192,11 +205,15 @@ func (tailer *Tailer) tailOnce(out []PublisherChannels, stop <-chan bool, readOr
 		return &ts, nil
 	})
 
+	if startTimeErr != nil {
+		return errFailedToStart
+	}
+
 	query, queryErr := issueOplogFindQuery(oplogCollection, startTime)
 
 	if queryErr != nil {
 		log.Log.Errorw("Error issuing tail query", "error", queryErr)
-		return
+		return errFailedToStart
 	}
 
 	lastTimestamp := startTime
@@ -204,7 +221,7 @@ func (tailer *Tailer) tailOnce(out []PublisherChannels, stop <-chan bool, readOr
 		select {
 		case <-stop:
 			log.Log.Infof("Received stop; aborting oplog tailing")
-			return
+			return nil
 		default:
 		}
 
@@ -266,7 +283,7 @@ func (tailer *Tailer) tailOnce(out []PublisherChannels, stop <-chan bool, readOr
 
 				if queryErr != nil {
 					log.Log.Errorw("Error issuing tail query", "error", queryErr)
-					return
+					return nil
 				}
 
 				break
@@ -277,7 +294,7 @@ func (tailer *Tailer) tailOnce(out []PublisherChannels, stop <-chan bool, readOr
 
 				if queryErr != nil {
 					log.Log.Errorw("Error issuing tail query", "error", queryErr)
-					return
+					return nil
 				}
 
 				break
@@ -287,13 +304,13 @@ func (tailer *Tailer) tailOnce(out []PublisherChannels, stop <-chan bool, readOr
 
 				closeCursor(query)
 
-				return
+				return nil
 			} else {
 				log.Log.Errorw("Got no data from cursor, but also no error. This is unexpected; restarting query")
 
 				closeCursor(query)
 
-				return
+				return nil
 			}
 		}
 	}
@@ -447,7 +464,7 @@ func (tailer *Tailer) processEntry(rawData bson.Raw, readOrdinal int) (timestamp
 // We take the function to get the timestamp of the last oplog entry (as a
 // fallback if we don't have a latest timestamp from Redis) as an arg instead
 // of using tailer.mongoClient directly so we can unit test this function
-func (tailer *Tailer) getStartTime(maxOrdinal int, getTimestampOfLastOplogEntry func() (*primitive.Timestamp, error)) primitive.Timestamp {
+func (tailer *Tailer) getStartTime(maxOrdinal int, getTimestampOfLastOplogEntry func() (*primitive.Timestamp, error)) (primitive.Timestamp, error) {
 	var redisErr error
 
 	for tries := 0; tries < config.ResumeTsReadRetries(); tries++ {
@@ -463,7 +480,7 @@ func (tailer *Tailer) getStartTime(maxOrdinal int, getTimestampOfLastOplogEntry 
 					"timestamp", tsTime.Unix(),
 					"age_seconds", gapSeconds)
 				metricOplogResumeGap.WithLabelValues("success").Observe(float64(gapSeconds))
-				return ts
+				return ts, nil
 			}
 
 			log.Log.Warnw("Found last processed timestamp, but it was too far in the past. Will start from end of oplog",
@@ -493,12 +510,12 @@ func (tailer *Tailer) getStartTime(maxOrdinal int, getTimestampOfLastOplogEntry 
 	if mongoErr == nil {
 		log.Log.Infow("Starting tailing from end of oplog",
 			"timestamp", mongoOplogEndTimestamp.T)
-		return *mongoOplogEndTimestamp
+		return *mongoOplogEndTimestamp, nil
 	}
 
-	log.Log.Errorw("Got error when asking for last operation timestamp in the oplog. Returning current time.",
+	log.Log.Errorw("Got error when asking for last operation timestamp in the oplog.",
 		"error", mongoErr)
-	return primitive.Timestamp{T: uint32(time.Now().Unix())}
+	return primitive.Timestamp{}, mongoErr
 }
 
 func parseID(idRaw bson.RawValue) (id interface{}, err error) {

--- a/lib/oplog/tail.go
+++ b/lib/oplog/tail.go
@@ -113,12 +113,12 @@ var (
 		Buckets:   []float64{1, 2.5, 5, 10, 25, 50, 100, 250, 500, 1000},
 	}, []string{"status"})
 
-	metricTailFailedToStart = promauto.NewCounter(prometheus.CounterOpts{
+	metricTailFailedToStart = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "otr",
 		Subsystem: "oplog",
 		Name:      "tail_failed_to_start",
-		Help:      "Number of times oplog tailing failed to start",
-	})
+		Help:      "Number of times oplog tailing failed to start, partitioned by reason",
+	}, []string{"reason"})
 )
 
 var errFailedToStart = errors.New("failed to start tailing")
@@ -147,15 +147,11 @@ func (tailer *Tailer) Tail(out []PublisherChannels, stop <-chan bool, readOrdina
 
 	for {
 		log.Log.Info("Starting oplog tailing")
-		err := tailer.tailOnce(out, childStopC, readOrdinal, readParallelism)
+		tailer.tailOnce(out, childStopC, readOrdinal, readParallelism)
 		log.Log.Info("Oplog tailing ended")
 
 		if wasStopped {
 			return
-		}
-
-		if errors.Is(err, errFailedToStart) {
-			metricTailFailedToStart.Inc()
 		}
 
 		log.Log.Errorw("Oplog tailing stopped prematurely. Waiting a second an then retrying.")
@@ -170,6 +166,7 @@ func (tailer *Tailer) tailOnce(out []PublisherChannels, stop <-chan bool, readOr
 	session, err := tailer.MongoClient.StartSession()
 	if err != nil {
 		log.Log.Errorw("Failed to start Mongo session", "error", err)
+		metricTailFailedToStart.WithLabelValues("session").Inc()
 		return errFailedToStart
 	}
 
@@ -206,13 +203,16 @@ func (tailer *Tailer) tailOnce(out []PublisherChannels, stop <-chan bool, readOr
 	})
 
 	if startTimeErr != nil {
+		log.Log.Errorw("Failed to determine oplog start time", "error", startTimeErr)
+		metricTailFailedToStart.WithLabelValues("start_time").Inc()
 		return errFailedToStart
 	}
 
 	query, queryErr := issueOplogFindQuery(oplogCollection, startTime)
 
 	if queryErr != nil {
-		log.Log.Errorw("Error issuing tail query", "error", queryErr)
+		log.Log.Errorw("Error issuing initial tail query", "error", queryErr)
+		metricTailFailedToStart.WithLabelValues("query").Inc()
 		return errFailedToStart
 	}
 

--- a/lib/oplog/tail.go
+++ b/lib/oplog/tail.go
@@ -121,13 +121,6 @@ var (
 	}, []string{"reason"})
 )
 
-// Start failure reason labels for the metricTailFailedToStart counter.
-const (
-	startFailureSession   = "session"
-	startFailureStartTime = "start_time"
-	startFailureQuery     = "query"
-)
-
 func init() {
 	prometheus.MustRegister(metricMaxOplogEntryByMinute)
 }
@@ -171,7 +164,7 @@ func (tailer *Tailer) tailOnce(out []PublisherChannels, stop <-chan bool, readOr
 	session, err := tailer.MongoClient.StartSession()
 	if err != nil {
 		log.Log.Errorw("Failed to start Mongo session", "error", err)
-		metricTailFailedToStart.WithLabelValues(startFailureSession).Inc()
+		metricTailFailedToStart.WithLabelValues("session").Inc()
 		return
 	}
 
@@ -209,14 +202,14 @@ func (tailer *Tailer) tailOnce(out []PublisherChannels, stop <-chan bool, readOr
 
 	if startTimeErr != nil {
 		log.Log.Errorw("Failed to determine oplog start time, falling back to current time", "error", startTimeErr)
-		metricTailFailedToStart.WithLabelValues(startFailureStartTime).Inc()
+		metricTailFailedToStart.WithLabelValues("start_time").Inc()
 	}
 
 	query, queryErr := issueOplogFindQuery(oplogCollection, startTime)
 
 	if queryErr != nil {
 		log.Log.Errorw("Error issuing initial tail query", "error", queryErr)
-		metricTailFailedToStart.WithLabelValues(startFailureQuery).Inc()
+		metricTailFailedToStart.WithLabelValues("query").Inc()
 		return
 	}
 

--- a/lib/oplog/tail.go
+++ b/lib/oplog/tail.go
@@ -121,15 +121,13 @@ var (
 	}, []string{"reason"})
 )
 
-// startFailureReasons used as metric labels when tailOnce fails to start.
-// tailOnce returns *string: nil means tailing started (no startup failure).
-var (
-	startFailureSession   = stringPtr("session")
-	startFailureStartTime = stringPtr("start_time")
-	startFailureQuery     = stringPtr("query")
+// Start failure reasons used as metric labels when tailOnce fails to start.
+// tailOnce returns "": tailing started successfully (no startup failure).
+const (
+	startFailureSession   = "session"
+	startFailureStartTime = "start_time"
+	startFailureQuery     = "query"
 )
-
-func stringPtr(s string) *string { return &s }
 
 func init() {
 	prometheus.MustRegister(metricMaxOplogEntryByMinute)
@@ -162,8 +160,8 @@ func (tailer *Tailer) Tail(out []PublisherChannels, stop <-chan bool, readOrdina
 			return
 		}
 
-		if reason != nil {
-			metricTailFailedToStart.WithLabelValues(*reason).Inc()
+		if reason != "" {
+			metricTailFailedToStart.WithLabelValues(reason).Inc()
 		}
 
 		log.Log.Errorw("Oplog tailing stopped prematurely. Waiting a second an then retrying.", "startFailure", reason)
@@ -174,7 +172,7 @@ func (tailer *Tailer) Tail(out []PublisherChannels, stop <-chan bool, readOrdina
 // this accepts an array of PublisherChannels instances whose size is equal to the degree of write-parallelism.
 // Each incoming message will be routed to one of the PublisherChannels instances based on its parallelism key
 // (hash of the database name), then sent to every channel within that PublisherChannels instance.
-func (tailer *Tailer) tailOnce(out []PublisherChannels, stop <-chan bool, readOrdinal, readParallelism int) *string {
+func (tailer *Tailer) tailOnce(out []PublisherChannels, stop <-chan bool, readOrdinal, readParallelism int) string {
 	session, err := tailer.MongoClient.StartSession()
 	if err != nil {
 		log.Log.Errorw("Failed to start Mongo session", "error", err)
@@ -230,7 +228,7 @@ func (tailer *Tailer) tailOnce(out []PublisherChannels, stop <-chan bool, readOr
 		select {
 		case <-stop:
 			log.Log.Infof("Received stop; aborting oplog tailing")
-			return nil
+			return ""
 		default:
 		}
 
@@ -292,7 +290,7 @@ func (tailer *Tailer) tailOnce(out []PublisherChannels, stop <-chan bool, readOr
 
 				if queryErr != nil {
 					log.Log.Errorw("Error issuing tail query", "error", queryErr)
-					return nil
+					return ""
 				}
 
 				break
@@ -303,7 +301,7 @@ func (tailer *Tailer) tailOnce(out []PublisherChannels, stop <-chan bool, readOr
 
 				if queryErr != nil {
 					log.Log.Errorw("Error issuing tail query", "error", queryErr)
-					return nil
+					return ""
 				}
 
 				break
@@ -313,13 +311,13 @@ func (tailer *Tailer) tailOnce(out []PublisherChannels, stop <-chan bool, readOr
 
 				closeCursor(query)
 
-				return nil
+				return ""
 			} else {
 				log.Log.Errorw("Got no data from cursor, but also no error. This is unexpected; restarting query")
 
 				closeCursor(query)
 
-				return nil
+				return ""
 			}
 		}
 	}

--- a/lib/oplog/tail.go
+++ b/lib/oplog/tail.go
@@ -121,8 +121,7 @@ var (
 	}, []string{"reason"})
 )
 
-// Start failure reasons used as metric labels when tailOnce fails to start.
-// tailOnce returns "": tailing started successfully (no startup failure).
+// Start failure reason labels for the metricTailFailedToStart counter.
 const (
 	startFailureSession   = "session"
 	startFailureStartTime = "start_time"
@@ -153,18 +152,14 @@ func (tailer *Tailer) Tail(out []PublisherChannels, stop <-chan bool, readOrdina
 
 	for {
 		log.Log.Info("Starting oplog tailing")
-		reason := tailer.tailOnce(out, childStopC, readOrdinal, readParallelism)
+		tailer.tailOnce(out, childStopC, readOrdinal, readParallelism)
 		log.Log.Info("Oplog tailing ended")
 
 		if wasStopped {
 			return
 		}
 
-		if reason != "" {
-			metricTailFailedToStart.WithLabelValues(reason).Inc()
-		}
-
-		log.Log.Errorw("Oplog tailing stopped prematurely. Waiting a second an then retrying.", "startFailure", reason)
+		log.Log.Errorw("Oplog tailing stopped prematurely. Waiting a second an then retrying.")
 		time.Sleep(requeryDuration)
 	}
 }
@@ -172,11 +167,12 @@ func (tailer *Tailer) Tail(out []PublisherChannels, stop <-chan bool, readOrdina
 // this accepts an array of PublisherChannels instances whose size is equal to the degree of write-parallelism.
 // Each incoming message will be routed to one of the PublisherChannels instances based on its parallelism key
 // (hash of the database name), then sent to every channel within that PublisherChannels instance.
-func (tailer *Tailer) tailOnce(out []PublisherChannels, stop <-chan bool, readOrdinal, readParallelism int) string {
+func (tailer *Tailer) tailOnce(out []PublisherChannels, stop <-chan bool, readOrdinal, readParallelism int) {
 	session, err := tailer.MongoClient.StartSession()
 	if err != nil {
 		log.Log.Errorw("Failed to start Mongo session", "error", err)
-		return startFailureSession
+		metricTailFailedToStart.WithLabelValues(startFailureSession).Inc()
+		return
 	}
 
 	oplogCollection := session.Client().Database("local").Collection("oplog.rs")
@@ -212,15 +208,16 @@ func (tailer *Tailer) tailOnce(out []PublisherChannels, stop <-chan bool, readOr
 	})
 
 	if startTimeErr != nil {
-		log.Log.Errorw("Failed to determine oplog start time", "error", startTimeErr)
-		return startFailureStartTime
+		log.Log.Errorw("Failed to determine oplog start time, falling back to current time", "error", startTimeErr)
+		metricTailFailedToStart.WithLabelValues(startFailureStartTime).Inc()
 	}
 
 	query, queryErr := issueOplogFindQuery(oplogCollection, startTime)
 
 	if queryErr != nil {
 		log.Log.Errorw("Error issuing initial tail query", "error", queryErr)
-		return startFailureQuery
+		metricTailFailedToStart.WithLabelValues(startFailureQuery).Inc()
+		return
 	}
 
 	lastTimestamp := startTime
@@ -228,7 +225,7 @@ func (tailer *Tailer) tailOnce(out []PublisherChannels, stop <-chan bool, readOr
 		select {
 		case <-stop:
 			log.Log.Infof("Received stop; aborting oplog tailing")
-			return ""
+			return
 		default:
 		}
 
@@ -290,7 +287,7 @@ func (tailer *Tailer) tailOnce(out []PublisherChannels, stop <-chan bool, readOr
 
 				if queryErr != nil {
 					log.Log.Errorw("Error issuing tail query", "error", queryErr)
-					return ""
+					return
 				}
 
 				break
@@ -301,7 +298,7 @@ func (tailer *Tailer) tailOnce(out []PublisherChannels, stop <-chan bool, readOr
 
 				if queryErr != nil {
 					log.Log.Errorw("Error issuing tail query", "error", queryErr)
-					return ""
+					return
 				}
 
 				break
@@ -311,13 +308,13 @@ func (tailer *Tailer) tailOnce(out []PublisherChannels, stop <-chan bool, readOr
 
 				closeCursor(query)
 
-				return ""
+				return
 			} else {
 				log.Log.Errorw("Got no data from cursor, but also no error. This is unexpected; restarting query")
 
 				closeCursor(query)
 
-				return ""
+				return
 			}
 		}
 	}
@@ -520,9 +517,9 @@ func (tailer *Tailer) getStartTime(maxOrdinal int, getTimestampOfLastOplogEntry 
 		return *mongoOplogEndTimestamp, nil
 	}
 
-	log.Log.Errorw("Got error when asking for last operation timestamp in the oplog.",
+	log.Log.Errorw("Got error when asking for last operation timestamp in the oplog. Returning current time.",
 		"error", mongoErr)
-	return primitive.Timestamp{}, mongoErr
+	return primitive.Timestamp{T: uint32(time.Now().Unix())}, mongoErr
 }
 
 func parseID(idRaw bson.RawValue) (id interface{}, err error) {

--- a/lib/oplog/tail.go
+++ b/lib/oplog/tail.go
@@ -121,7 +121,15 @@ var (
 	}, []string{"reason"})
 )
 
-var errFailedToStart = errors.New("failed to start tailing")
+// startFailureReasons used as metric labels when tailOnce fails to start.
+// tailOnce returns *string: nil means tailing started (no startup failure).
+var (
+	startFailureSession   = stringPtr("session")
+	startFailureStartTime = stringPtr("start_time")
+	startFailureQuery     = stringPtr("query")
+)
+
+func stringPtr(s string) *string { return &s }
 
 func init() {
 	prometheus.MustRegister(metricMaxOplogEntryByMinute)
@@ -147,14 +155,18 @@ func (tailer *Tailer) Tail(out []PublisherChannels, stop <-chan bool, readOrdina
 
 	for {
 		log.Log.Info("Starting oplog tailing")
-		tailer.tailOnce(out, childStopC, readOrdinal, readParallelism)
+		reason := tailer.tailOnce(out, childStopC, readOrdinal, readParallelism)
 		log.Log.Info("Oplog tailing ended")
 
 		if wasStopped {
 			return
 		}
 
-		log.Log.Errorw("Oplog tailing stopped prematurely. Waiting a second an then retrying.")
+		if reason != nil {
+			metricTailFailedToStart.WithLabelValues(*reason).Inc()
+		}
+
+		log.Log.Errorw("Oplog tailing stopped prematurely. Waiting a second an then retrying.", "startFailure", reason)
 		time.Sleep(requeryDuration)
 	}
 }
@@ -162,12 +174,11 @@ func (tailer *Tailer) Tail(out []PublisherChannels, stop <-chan bool, readOrdina
 // this accepts an array of PublisherChannels instances whose size is equal to the degree of write-parallelism.
 // Each incoming message will be routed to one of the PublisherChannels instances based on its parallelism key
 // (hash of the database name), then sent to every channel within that PublisherChannels instance.
-func (tailer *Tailer) tailOnce(out []PublisherChannels, stop <-chan bool, readOrdinal, readParallelism int) error {
+func (tailer *Tailer) tailOnce(out []PublisherChannels, stop <-chan bool, readOrdinal, readParallelism int) *string {
 	session, err := tailer.MongoClient.StartSession()
 	if err != nil {
 		log.Log.Errorw("Failed to start Mongo session", "error", err)
-		metricTailFailedToStart.WithLabelValues("session").Inc()
-		return errFailedToStart
+		return startFailureSession
 	}
 
 	oplogCollection := session.Client().Database("local").Collection("oplog.rs")
@@ -204,16 +215,14 @@ func (tailer *Tailer) tailOnce(out []PublisherChannels, stop <-chan bool, readOr
 
 	if startTimeErr != nil {
 		log.Log.Errorw("Failed to determine oplog start time", "error", startTimeErr)
-		metricTailFailedToStart.WithLabelValues("start_time").Inc()
-		return errFailedToStart
+		return startFailureStartTime
 	}
 
 	query, queryErr := issueOplogFindQuery(oplogCollection, startTime)
 
 	if queryErr != nil {
 		log.Log.Errorw("Error issuing initial tail query", "error", queryErr)
-		metricTailFailedToStart.WithLabelValues("query").Inc()
-		return errFailedToStart
+		return startFailureQuery
 	}
 
 	lastTimestamp := startTime

--- a/lib/oplog/tail_test.go
+++ b/lib/oplog/tail_test.go
@@ -52,6 +52,7 @@ func TestGetStartTime(t *testing.T) {
 		mongoEndOfOplogErr error
 		redisErr           string
 		expectedResult     primitive.Timestamp
+		expectedErr        bool
 	}{
 		"Start time is in Redis": {
 			redisTimestamp: mongoTS(notTooOld),
@@ -71,7 +72,7 @@ func TestGetStartTime(t *testing.T) {
 		},
 		"Start time not in Redis, Mongo errors": {
 			mongoEndOfOplogErr: errors.New("Some mongo error"),
-			expectedResult:     mongoTS(now),
+			expectedErr:        true,
 		},
 		"Start time is in Redis, redis errors first attempt": {
 			redisTimestamp: mongoTS(notTooOld),
@@ -113,7 +114,7 @@ func TestGetStartTime(t *testing.T) {
 				Denylist:     &sync.Map{},
 			}
 
-			actualResult := tailer.getStartTime(0, func() (*primitive.Timestamp, error) {
+			actualResult, err := tailer.getStartTime(0, func() (*primitive.Timestamp, error) {
 				if test.mongoEndOfOplogErr != nil {
 					return nil, test.mongoEndOfOplogErr
 				}
@@ -121,10 +122,13 @@ func TestGetStartTime(t *testing.T) {
 				return &test.mongoEndOfOplog, nil
 			})
 
-			// We need to do an approximate comparison; the function sometimes
-			// return time.Now
-			if !timestampsWithinDelta(actualResult, test.expectedResult, time.Second) {
-				t.Errorf("Result was incorrect. Got %d, expected %d", actualResult, test.expectedResult)
+			if test.expectedErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				if !timestampsWithinDelta(actualResult, test.expectedResult, time.Second) {
+					t.Errorf("Result was incorrect. Got %d, expected %d", actualResult, test.expectedResult)
+				}
 			}
 		})
 	}

--- a/lib/oplog/tail_test.go
+++ b/lib/oplog/tail_test.go
@@ -72,6 +72,7 @@ func TestGetStartTime(t *testing.T) {
 		},
 		"Start time not in Redis, Mongo errors": {
 			mongoEndOfOplogErr: errors.New("Some mongo error"),
+			expectedResult:     mongoTS(now),
 			expectedErr:        true,
 		},
 		"Start time is in Redis, redis errors first attempt": {
@@ -126,9 +127,10 @@ func TestGetStartTime(t *testing.T) {
 				require.Error(t, err)
 			} else {
 				require.NoError(t, err)
-				if !timestampsWithinDelta(actualResult, test.expectedResult, time.Second) {
-					t.Errorf("Result was incorrect. Got %d, expected %d", actualResult, test.expectedResult)
-				}
+			}
+
+			if !timestampsWithinDelta(actualResult, test.expectedResult, time.Second) {
+				t.Errorf("Result was incorrect. Got %d, expected %d", actualResult, test.expectedResult)
 			}
 		})
 	}


### PR DESCRIPTION
When `tailOnce` fails before it starts reading the oplog (session start, fetching start timestamp, or issuing the initial query), it returns a start failure reason. The Tail loop increments `otr_oplog_tail_failed_to_start` with a reason label (session, start_time, query) so the specific failure point is visible in Grafana without checking logs.                       
                                                                                                
Previously, `getStartTime` swallowed Mongo errors and silently fell back to `time.Now()`. It now returns the error so it surfaces as a startup failure. Transient errors still recover since Tail retries on failure.

Alert added to kiwi: https://github.com/tulip/kiwi/pull/6235 