### PR TITLE
Publisher: Add metric for age of oldest unpublished message

### DIFF
--- a/integration-tests/fault-injection/redisStopStart_test.go
+++ b/integration-tests/fault-injection/redisStopStart_test.go
@@ -61,7 +61,6 @@ func TestRedisStopStart(t *testing.T) {
 
 	nSuccess := harness.FindPromMetricCounter(metrics, "otr_redispub_processed_messages", map[string]string{
 		"status": "sent",
-		"idx":    "0",
 	})
 	if nSuccess != 100 {
 		t.Errorf("Metric otr_redispub_processed_messages(status: sent) = %d, expected 100", nSuccess)
@@ -69,7 +68,6 @@ func TestRedisStopStart(t *testing.T) {
 
 	nPermFail := harness.FindPromMetricCounter(metrics, "otr_redispub_processed_messages", map[string]string{
 		"status": "failed",
-		"idx":    "0",
 	})
 	if nPermFail != 0 {
 		t.Errorf("Metric otr_redispub_processed_messages(status: failed) = %d, expected 0", nPermFail)

--- a/lib/redispub/publisher.go
+++ b/lib/redispub/publisher.go
@@ -168,7 +168,6 @@ func PublishStream(client redis.UniversalClient, in <-chan *Publication, opts *P
 
 		metricStalenessPreRetries.WithLabelValues(strconv.Itoa(ordinal)).Set(time.Since(p.WallTime).Seconds())
 		err := publishSingleMessageWithRetries(p, 30, time.Second, publishFn)
-		lastSeenPub = nil
 		log.Log.Debugw("Published to", "ordinal", ordinal, "clientIndex", clientIndex)
 
 		if err != nil {

--- a/lib/redispub/publisher.go
+++ b/lib/redispub/publisher.go
@@ -49,7 +49,7 @@ var metricSentMessages = promauto.NewCounterVec(prometheus.CounterOpts{
 	Namespace: "otr",
 	Subsystem: "redispub",
 	Name:      "processed_messages",
-	Help:      "Messages processed by Redis publisher, partitioned by whether or not we successfully sent them and publish function index",
+	Help:      "Messages processed by Redis publisher, partitioned by whether or not we successfully sent them",
 }, []string{"status"})
 
 var metricTemporaryFailures = promauto.NewCounter(prometheus.CounterOpts{

--- a/lib/redispub/publisher.go
+++ b/lib/redispub/publisher.go
@@ -109,31 +109,81 @@ func PublishStream(client redis.UniversalClient, in <-chan *Publication, opts *P
 	metricSendFailed := metricSentMessages.WithLabelValues("failed")
 	metricSendSuccess := metricSentMessages.WithLabelValues("sent")
 
+	// this is the item that is logically at the head of the queue
+	// populate it every time something is pulled from the channel, and clear it if the channel becomes empty
+	// since the queue is in reverse chronological order, this is the oldest item, so we use it
+	// to drive that metric.
+	// 		- 	if the queue is empty, this will be nil (since it will have been cleared after
+	// 			the last publish and we are blocking)
+	//		- 	if the publish is stalled, this will be the item that is stuck trying to publish
+	//		-	under normal operation, this will cycle rapidly
+	var lastSeenPub *Publication = nil
+
+	promauto.NewGaugeFunc(prometheus.GaugeOpts{
+		Namespace:   "otr",
+		Subsystem:   "redispub",
+		Name:        "oldest_message_age",
+		Help:        "Gauge indicating the age of the oldest seen-but-unprocessed message.",
+		ConstLabels: prometheus.Labels{"ordinal": strconv.Itoa(ordinal), "clientIndex": strconv.Itoa(clientIndex)},
+	}, func() float64 {
+		if lastSeenPub == nil {
+			return 0
+		} else {
+			return float64(math.Max(time.Since(lastSeenPub.WallTime).Seconds(), 0))
+		}
+	})
+
+	// main publisher loop:
 	for {
+		// try a non-blocking select{} first, then a blocking one. This way if the queue is
+		// nonempty, we can proceed normally, but if it's ever empty, the blocking one will fall through
+		// and we can reset the oldest-message metric before proceeding to the blocking one.
+
+		var p *Publication = nil
 		select {
 		case <-stop:
+			// we need to check the stop signal in both
 			close(timestampC)
 			return
+		case p = <-in:
+			// queue not empty, so we can proceed immediately
+			lastSeenPub = p
+		default:
+			// queue is empty, clear the metric and block until something happens
+			lastSeenPub = nil
 
-		case p := <-in:
-			metricStalenessPreRetries.WithLabelValues(strconv.Itoa(ordinal)).Set(time.Since(p.WallTime).Seconds())
-			err := publishSingleMessageWithRetries(p, 30, time.Second, publishFn)
-			log.Log.Debugw("Published to", "ordinal", ordinal, "clientIndex", clientIndex)
-
-			if err != nil {
-				metricSendFailed.Inc()
-				log.Log.Errorw("Permanent error while trying to publish message; giving up",
-					"error", err,
-					"message", p)
-			} else {
-				metricSendSuccess.Inc()
-
-				// We want to make sure we do this *after* we've successfully published
-				// the messages
-				timestampC <- p.OplogTimestamp
+			select {
+			case <-stop:
+				// stop signal came in while we were blocked
+				close(timestampC)
+				return
+			case p = <-in:
+				// message arrived, so proceed
+				lastSeenPub = p
 			}
-
 		}
+
+		// p guaranteed to be non-nil since the only exits from the select{} sequence is
+		// getting a message or a stop signal (which would have returned already)
+
+		metricStalenessPreRetries.WithLabelValues(strconv.Itoa(ordinal)).Set(time.Since(p.WallTime).Seconds())
+		err := publishSingleMessageWithRetries(p, 30, time.Second, publishFn)
+		lastSeenPub = nil
+		log.Log.Debugw("Published to", "ordinal", ordinal, "clientIndex", clientIndex)
+
+		if err != nil {
+			metricSendFailed.Inc()
+			log.Log.Errorw("Permanent error while trying to publish message; giving up",
+				"error", err,
+				"message", p)
+		} else {
+			metricSendSuccess.Inc()
+
+			// We want to make sure we do this *after* we've successfully published
+			// the messages
+			timestampC <- p.OplogTimestamp
+		}
+
 	}
 }
 

--- a/lib/redispub/publisher.go
+++ b/lib/redispub/publisher.go
@@ -50,7 +50,7 @@ var metricSentMessages = promauto.NewCounterVec(prometheus.CounterOpts{
 	Subsystem: "redispub",
 	Name:      "processed_messages",
 	Help:      "Messages processed by Redis publisher, partitioned by whether or not we successfully sent them and publish function index",
-}, []string{"status", "idx"})
+}, []string{"status"})
 
 var metricTemporaryFailures = promauto.NewCounter(prometheus.CounterOpts{
 	Namespace: "otr",
@@ -91,39 +91,23 @@ var metricOplogEntryStaleness = promauto.NewHistogramVec(prometheus.HistogramOpt
 
 // PublishStream reads Publications from the given channel and publishes them
 // to Redis.
-func PublishStream(clients []redis.UniversalClient, in <-chan *Publication, opts *PublishOpts, stop <-chan bool, ordinal int) {
+func PublishStream(client redis.UniversalClient, in <-chan *Publication, opts *PublishOpts, stop <-chan bool, ordinal int, clientIndex int) {
 
 	// Start up a background goroutine for periodically updating the last-processed
 	// timestamp
 	timestampC := make(chan primitive.Timestamp)
-	for _, client := range clients {
-		go periodicallyUpdateTimestamp(client, timestampC, opts, ordinal)
-	}
+	go periodicallyUpdateTimestamp(client, timestampC, opts, ordinal)
 
 	// Redis expiration is in integer seconds, so we have to convert the
 	// time.Duration
 	dedupeExpirationSeconds := int(opts.DedupeExpiration.Seconds())
 
-	type PubFn func(*Publication) error
-
-	var publishFns []PubFn
-
-	for _, client := range clients {
-		client := client
-		publishFn := func(p *Publication) error {
-			return publishSingleMessage(p, client, opts.MetadataPrefix, dedupeExpirationSeconds, ordinal)
-		}
-		publishFns = append(publishFns, publishFn)
+	publishFn := func(p *Publication) error {
+		return publishSingleMessage(p, client, opts.MetadataPrefix, dedupeExpirationSeconds, ordinal)
 	}
 
-	publishFnsCount := len(publishFns)
-	metricsSendFailed := make([]prometheus.Counter, publishFnsCount)  //metricSentMessages.WithLabelValues("failed")
-	metricsSendSuccess := make([]prometheus.Counter, publishFnsCount) //metricSentMessages.WithLabelValues("sent")
-	for i := 0; i < publishFnsCount; i++ {
-		idx := strconv.Itoa(i)
-		metricsSendFailed[i] = metricSentMessages.WithLabelValues("failed", idx)
-		metricsSendSuccess[i] = metricSentMessages.WithLabelValues("sent", idx)
-	}
+	metricSendFailed := metricSentMessages.WithLabelValues("failed")
+	metricSendSuccess := metricSentMessages.WithLabelValues("sent")
 
 	for {
 		select {
@@ -133,23 +117,22 @@ func PublishStream(clients []redis.UniversalClient, in <-chan *Publication, opts
 
 		case p := <-in:
 			metricStalenessPreRetries.WithLabelValues(strconv.Itoa(ordinal)).Set(time.Since(p.WallTime).Seconds())
-			for i, publishFn := range publishFns {
-				err := publishSingleMessageWithRetries(p, 30, time.Second, publishFn)
-				log.Log.Debugw("Published to", "idx", i)
+			err := publishSingleMessageWithRetries(p, 30, time.Second, publishFn)
+			log.Log.Debugw("Published to", "ordinal", ordinal, "clientIndex", clientIndex)
 
-				if err != nil {
-					metricsSendFailed[i].Inc()
-					log.Log.Errorw("Permanent error while trying to publish message; giving up",
-						"error", err,
-						"message", p)
-				} else {
-					metricsSendSuccess[i].Inc()
+			if err != nil {
+				metricSendFailed.Inc()
+				log.Log.Errorw("Permanent error while trying to publish message; giving up",
+					"error", err,
+					"message", p)
+			} else {
+				metricSendSuccess.Inc()
 
-					// We want to make sure we do this *after* we've successfully published
-					// the messages
-					timestampC <- p.OplogTimestamp
-				}
+				// We want to make sure we do this *after* we've successfully published
+				// the messages
+				timestampC <- p.OplogTimestamp
 			}
+
 		}
 	}
 }

--- a/main.go
+++ b/main.go
@@ -112,11 +112,11 @@ func main() {
 			//
 			// TODO PERF: Use a leaky buffer (https://github.com/tulip/oplogtoredis/issues/2)
 			go func(ordinal int, clientIndex int) {
-				redispub.PublishStream([]redis.UniversalClient{redisClient}, redisPubs, &redispub.PublishOpts{
+				redispub.PublishStream(redisClient, redisPubs, &redispub.PublishOpts{
 					FlushInterval:    config.TimestampFlushInterval(),
 					DedupeExpiration: config.RedisDedupeExpiration(),
 					MetadataPrefix:   config.RedisMetadataPrefix(),
-				}, stopRedisPub, ordinal)
+				}, stopRedisPub, ordinal, clientIndex)
 				log.Log.Infow("Redis publisher completed", "ordinal", ordinal, "clientIndex", clientIndex)
 				waitGroup.Done()
 			}(i, j)


### PR DESCRIPTION
## Summary
Add a new metric representing the age (wall time seconds) of the message most recently dequeued. The specific semantics are that we maintain a reference to the most recently dequeued message. After each publish, we check if the queue is empty. If it is, we clear the reference, causing the gauge to drop to 0. If it's not, we overwrite the reference with the next item from the queue. In normal operation, this value will be replaced as we continually dequeue messages. If the queue empties, it will drop to 0. However, if the redis publication is stalled, the same message will be kept in the reference, so every time the prometheus scrape occurs, the gauge will climb higher.

Also slightly refactor PublishStream to not use an unnecessary array.

## Level of Impact

Please select exactly one option. To change the level of impact, first unselect the current level of impact and then select the new level of impact.

- [ ] 1 - High
- [ ] 2 - Medium
- [X] 3 - Low
- [ ] 4 - No-op

## Impact Analysis
Small refactor and cleaned up existing log messages and extraneous old metrics labels in addition to the new ones.

## Test Plan
CI should cover main functionality is unchanged.

## Checklist

- [X] Test Plan Fully Executed
- [X] Does not require security review or security review complete
