### PR TITLE
Set default redis batch to 1

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 buildGoModule {
   pname = "oplogtoredis";
-  version = "3.9.0";
+  version = "3.9.1";
   src = builtins.path { path = ./.; };
 
   postInstall = ''

--- a/lib/config/main.go
+++ b/lib/config/main.go
@@ -31,7 +31,7 @@ type oplogtoredisConfiguration struct {
 	SentryRelease                 string        `default:"unknown" split_words:"true"`
 	ResumeTsReadRetries           int           `default:"5" split_words:"true"`
 	ResumeTsReadRetryDelay        time.Duration `default:"500ms" split_words:"true"`
-	RedisBatchSize		          int           `default:"25" split_words:"true"`
+	RedisBatchSize		            int           `default:"1" split_words:"true"`
 }
 
 var globalConfig *oplogtoredisConfiguration


### PR DESCRIPTION
This PR sets the default redis batch size to one so that rolling out the latest batching feature is a no-op until the new `REDIS_BATCH_SIZE` environment variable is set.  This was an afterthought after having merged the redis batch feature.