### PR TITLE
Retry on Redis read failure when resuming oplog tailing

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 buildGoModule {
   pname = "oplogtoredis";
-  version = "3.9.2";
+  version = "3.9.3";
   src = builtins.path { path = ./.; };
 
   postInstall = ''

--- a/lib/config/main.go
+++ b/lib/config/main.go
@@ -31,6 +31,7 @@ type oplogtoredisConfiguration struct {
 	SentryRelease                 string        `default:"unknown" split_words:"true"`
 	ResumeTsReadRetries           int           `default:"5" split_words:"true"`
 	ResumeTsReadRetryDelay        time.Duration `default:"500ms" split_words:"true"`
+	ResumeFromEndOnFailure        bool          `default:"false" split_words:"true"`
 	RedisBatchSize		            int           `default:"1" split_words:"true"`
 }
 
@@ -198,6 +199,23 @@ func ResumeTsReadRetries() int {
 // e.g., third attempt = 500ms * 3 = 1.5s delay before next attempt.
 func ResumeTsReadRetryDelay() time.Duration {
 	return globalConfig.ResumeTsReadRetryDelay
+}
+
+// ResumeFromEndOnFailure controls the behavior when reading the resume
+// timestamp from Redis fails persistently (i.e. after exhausting
+// ResumeTsReadRetries). By default (false), oplogtoredis aborts the tail
+// attempt and retries rather than skipping ahead, since a failure to read the
+// resume timestamp would otherwise silently drop every oplog entry written
+// since the last processed position.
+//
+// This flag is an escape hatch: if set to true, a persistent read failure
+// falls back to starting from the end of the oplog (the pre-retry behavior),
+// at the cost of potentially skipping oplog entries. Use this only if an
+// unanticipated situation is blocking startup and you would rather resume from
+// the end of the oplog than stay down. It is set via the environment variable
+// `OTR_RESUME_FROM_END_ON_FAILURE` and defaults to false.
+func ResumeFromEndOnFailure() bool {
+	return globalConfig.ResumeFromEndOnFailure
 }
 
 // RedisBatchSize is the maximum number of publications to batch per redis call

--- a/lib/oplog/tail.go
+++ b/lib/oplog/tail.go
@@ -506,12 +506,24 @@ func (tailer *Tailer) getStartTime(maxOrdinal int, getTimestampOfLastOplogEntry 
 	// oplog here would silently skip every entry written since our last processed
 	// timestamp, so instead we return the error and let the caller restart and retry.
 	// If we can't read from Redis, we can't write to it either, so retrying is correct.
+	//
+	// The OTR_RESUME_FROM_END_ON_FAILURE escape hatch overrides this: if set, we fall
+	// back to the end of the oplog (the pre-retry behavior) rather than blocking
+	// startup, accepting the risk of skipping entries.
 	if redisErr != nil && !errors.Is(redisErr, redis.Nil) {
-		metricOplogResumeGap.WithLabelValues("failed").Observe(0) // zero because we failed to get the timestamp
+		if !config.ResumeFromEndOnFailure() {
+			metricOplogResumeGap.WithLabelValues("failed").Observe(0) // zero because we failed to get the timestamp
+			log.Log.Errorw("Error querying Redis for last processed timestamp after exhausting retries; "+
+				"aborting tail attempt so it can be retried rather than skipping oplog entries",
+				"error", redisErr)
+			return primitive.Timestamp{}, redisErr
+		}
+
 		log.Log.Errorw("Error querying Redis for last processed timestamp after exhausting retries; "+
-			"aborting tail attempt so it can be retried rather than skipping oplog entries",
+			"OTR_RESUME_FROM_END_ON_FAILURE is set, so falling back to the end of the oplog "+
+			"(this may skip oplog entries)",
 			"error", redisErr)
-		return primitive.Timestamp{}, redisErr
+		metricOplogResumeGap.WithLabelValues("failed").Observe(0) // zero because we failed to get the timestamp
 	}
 
 	mongoOplogEndTimestamp, mongoErr := getTimestampOfLastOplogEntry()

--- a/lib/oplog/tail.go
+++ b/lib/oplog/tail.go
@@ -201,8 +201,9 @@ func (tailer *Tailer) tailOnce(out []PublisherChannels, stop <-chan bool, readOr
 	})
 
 	if startTimeErr != nil {
-		log.Log.Errorw("Failed to determine oplog start time, falling back to current time", "error", startTimeErr)
+		log.Log.Errorw("Failed to determine oplog start time; aborting tail attempt to retry", "error", startTimeErr)
 		metricTailFailedToStart.WithLabelValues("start_time").Inc()
+		return
 	}
 
 	query, queryErr := issueOplogFindQuery(oplogCollection, startTime)
@@ -466,7 +467,10 @@ func (tailer *Tailer) getStartTime(maxOrdinal int, getTimestampOfLastOplogEntry 
 
 	for tries := 0; tries < config.ResumeTsReadRetries(); tries++ {
 		// Get the earliest "last processed time" for each shard. This assumes that the number of shards is constant.
-		ts, tsTime, redisErr := redispub.FirstLastProcessedTimestamp(tailer.RedisClients[0], tailer.RedisPrefix, maxOrdinal)
+		// Note: assign to the outer redisErr (with =, not :=) so the post-loop handler can see a persistent failure.
+		var ts primitive.Timestamp
+		var tsTime time.Time
+		ts, tsTime, redisErr = redispub.FirstLastProcessedTimestamp(tailer.RedisClients[0], tailer.RedisPrefix, maxOrdinal)
 
 		if redisErr == nil {
 			gapSeconds := time.Since(tsTime) / time.Second
@@ -485,11 +489,11 @@ func (tailer *Tailer) getStartTime(maxOrdinal int, getTimestampOfLastOplogEntry 
 				"age_seconds", gapSeconds)
 			metricOplogResumeGap.WithLabelValues("failed").Observe(float64(gapSeconds))
 			break
-		} else if redisErr == redis.Nil {
+		} else if errors.Is(redisErr, redis.Nil) {
 			log.Log.Errorw("No last processed timestamp found in Redis. Will start from end of oplog.",
 				"attempt", tries)
 			break
-		} else if (redisErr != nil) && (redisErr != redis.Nil) {
+		} else {
 			log.Log.Warnw("Error querying Redis for last processed timestamp. Will retry.",
 				"attempt", tries,
 				"error", redisErr)
@@ -497,10 +501,17 @@ func (tailer *Tailer) getStartTime(maxOrdinal int, getTimestampOfLastOplogEntry 
 		}
 	}
 
-	if redisErr != nil {
+	// A genuine read failure (as opposed to redis.Nil, which means there's simply no
+	// resume point yet) means we couldn't reach Redis. Falling back to the end of the
+	// oplog here would silently skip every entry written since our last processed
+	// timestamp, so instead we return the error and let the caller restart and retry.
+	// If we can't read from Redis, we can't write to it either, so retrying is correct.
+	if redisErr != nil && !errors.Is(redisErr, redis.Nil) {
 		metricOplogResumeGap.WithLabelValues("failed").Observe(0) // zero because we failed to get the timestamp
-		log.Log.Errorw("Error querying Redis for last processed timestamp. Will start from end of oplog.",
+		log.Log.Errorw("Error querying Redis for last processed timestamp after exhausting retries; "+
+			"aborting tail attempt so it can be retried rather than skipping oplog entries",
 			"error", redisErr)
+		return primitive.Timestamp{}, redisErr
 	}
 
 	mongoOplogEndTimestamp, mongoErr := getTimestampOfLastOplogEntry()

--- a/lib/oplog/tail_test.go
+++ b/lib/oplog/tail_test.go
@@ -14,6 +14,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
+
+	"github.com/tulip/oplogtoredis/lib/config"
 )
 
 func encodeMongoTimestamp(ts primitive.Timestamp) string {
@@ -41,6 +43,11 @@ func timestampsWithinDelta(d1, d2 primitive.Timestamp, delta time.Duration) bool
 }
 
 func TestGetStartTime(t *testing.T) {
+	// Use a tiny retry delay so the persistent-failure case, which exhausts all
+	// retries, completes well within the unit test timeout (CI runs -timeout 5s).
+	t.Setenv("OTR_RESUME_TS_READ_RETRY_DELAY", "1ms")
+	require.NoError(t, config.ParseEnv())
+
 	now := time.Now()
 	maxCatchUp := time.Minute
 	notTooOld := now.Add(-30 * time.Second)

--- a/lib/oplog/tail_test.go
+++ b/lib/oplog/tail_test.go
@@ -51,34 +51,55 @@ func TestGetStartTime(t *testing.T) {
 		mongoEndOfOplog    primitive.Timestamp
 		mongoEndOfOplogErr error
 		redisErr           string
-		expectedResult     primitive.Timestamp
-		expectedErr        bool
+		// redisErrAttempts is the number of leading GET calls that should fail with
+		// redisErr. Use a large value to simulate a persistent (unrecoverable) failure.
+		redisErrAttempts int
+		expectedResult   primitive.Timestamp
+		expectedErr      bool
+		// expectMongoFallback indicates whether getStartTime should consult the Mongo
+		// end-of-oplog fallback. On a persistent Redis read failure it must NOT, since
+		// that would silently skip oplog entries.
+		expectMongoFallback bool
 	}{
 		"Start time is in Redis": {
 			redisTimestamp: mongoTS(notTooOld),
 			expectedResult: mongoTS(notTooOld),
 		},
 		"Start time is in redis, but too old": {
-			redisTimestamp:  mongoTS(tooOld),
-			mongoEndOfOplog: mongoTS(notTooOld),
-			expectedResult:  mongoTS(notTooOld),
+			redisTimestamp:      mongoTS(tooOld),
+			mongoEndOfOplog:     mongoTS(notTooOld),
+			expectedResult:      mongoTS(notTooOld),
+			expectMongoFallback: true,
 		},
 		"Start time not in Redis": {
 			// We use tooOld here to make sure we're not applying any kind
 			// of cutoff to the latest oplog entry -- it's always fine to use
 			// that regardless of how old it is
-			mongoEndOfOplog: mongoTS(tooOld),
-			expectedResult:  mongoTS(tooOld),
+			mongoEndOfOplog:     mongoTS(tooOld),
+			expectedResult:      mongoTS(tooOld),
+			expectMongoFallback: true,
 		},
 		"Start time not in Redis, Mongo errors": {
-			mongoEndOfOplogErr: errors.New("Some mongo error"),
-			expectedResult:     mongoTS(now),
-			expectedErr:        true,
+			mongoEndOfOplogErr:  errors.New("Some mongo error"),
+			expectedResult:      mongoTS(now),
+			expectedErr:         true,
+			expectMongoFallback: true,
 		},
-		"Start time is in Redis, redis errors first attempt": {
-			redisTimestamp: mongoTS(notTooOld),
-			expectedResult: mongoTS(notTooOld),
-			redisErr:       "Some transient redis error",
+		"Start time is in Redis, redis errors first few attempts": {
+			redisTimestamp:   mongoTS(notTooOld),
+			expectedResult:   mongoTS(notTooOld),
+			redisErr:         "Some transient redis error",
+			redisErrAttempts: 3,
+		},
+		"Start time read from Redis fails persistently": {
+			// Every read attempt fails. We must NOT fall back to the end of the
+			// oplog (which would skip entries); instead getStartTime should return
+			// an error so the tailer restarts and retries.
+			redisTimestamp:      mongoTS(notTooOld),
+			redisErr:            "redis: all sentinels specified in configuration are unreachable",
+			redisErrAttempts:    1000,
+			expectedErr:         true,
+			expectMongoFallback: false,
 		},
 	}
 
@@ -92,9 +113,9 @@ func TestGetStartTime(t *testing.T) {
 			defer redisServer.Close()
 
 			redisGetErrorCount := 0
-			// Register a hook so we can clear the error
+			// Register a hook so we can fail the configured number of leading GETs
 			redisServer.Server().SetPreHook(func(c *server.Peer, cmd string, args ...string) bool {
-				if cmd == "GET" && test.redisErr != "" && redisGetErrorCount < 3 {
+				if cmd == "GET" && test.redisErr != "" && redisGetErrorCount < test.redisErrAttempts {
 					redisGetErrorCount += 1
 					c.WriteError(test.redisErr)
 					return true
@@ -115,7 +136,9 @@ func TestGetStartTime(t *testing.T) {
 				Denylist:     &sync.Map{},
 			}
 
+			mongoFallbackCalled := false
 			actualResult, err := tailer.getStartTime(0, func() (*primitive.Timestamp, error) {
+				mongoFallbackCalled = true
 				if test.mongoEndOfOplogErr != nil {
 					return nil, test.mongoEndOfOplogErr
 				}
@@ -129,8 +152,22 @@ func TestGetStartTime(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			if !timestampsWithinDelta(actualResult, test.expectedResult, time.Second) {
-				t.Errorf("Result was incorrect. Got %d, expected %d", actualResult, test.expectedResult)
+			require.Equal(t, test.expectMongoFallback, mongoFallbackCalled,
+				"unexpected use of the Mongo end-of-oplog fallback")
+
+			// On a persistent Redis read failure we must not return a usable start
+			// time at all, so skip the timestamp comparison for that case.
+			if !test.expectedErr || test.expectMongoFallback {
+				expectedResult := test.expectedResult
+				if test.mongoEndOfOplogErr != nil {
+					// The Mongo-error fallback returns the current time, so compare against
+					// the clock now rather than a value captured at the start of the test
+					// (other slow subtests can otherwise push us past the delta).
+					expectedResult = mongoTS(time.Now())
+				}
+				if !timestampsWithinDelta(actualResult, expectedResult, time.Second) {
+					t.Errorf("Result was incorrect. Got %d, expected %d", actualResult, expectedResult)
+				}
 			}
 		})
 	}

--- a/lib/oplog/tail_test.go
+++ b/lib/oplog/tail_test.go
@@ -63,6 +63,9 @@ func TestGetStartTime(t *testing.T) {
 		redisErrAttempts int
 		expectedResult   primitive.Timestamp
 		expectedErr      bool
+		// resumeFromEndOnFailure sets the OTR_RESUME_FROM_END_ON_FAILURE escape hatch
+		// for this subtest.
+		resumeFromEndOnFailure bool
 		// expectMongoFallback indicates whether getStartTime should consult the Mongo
 		// end-of-oplog fallback. On a persistent Redis read failure it must NOT, since
 		// that would silently skip oplog entries.
@@ -108,10 +111,31 @@ func TestGetStartTime(t *testing.T) {
 			expectedErr:         true,
 			expectMongoFallback: false,
 		},
+		"Start time read from Redis fails persistently, escape hatch enabled": {
+			// With OTR_RESUME_FROM_END_ON_FAILURE set, a persistent read failure
+			// falls back to the end of the oplog (the pre-retry behavior) instead
+			// of returning an error.
+			redisTimestamp:         mongoTS(notTooOld),
+			mongoEndOfOplog:        mongoTS(tooOld),
+			redisErr:               "redis: all sentinels specified in configuration are unreachable",
+			redisErrAttempts:       1000,
+			resumeFromEndOnFailure: true,
+			expectedResult:         mongoTS(tooOld),
+			expectMongoFallback:    true,
+		},
 	}
 
 	for testName, test := range tests {
 		t.Run(testName, func(t *testing.T) {
+			// Set explicitly (and re-parse) every subtest so config state from the
+			// escape-hatch case doesn't leak into others via the shared global config
+			// (subtests run in randomized order).
+			if test.resumeFromEndOnFailure {
+				t.Setenv("OTR_RESUME_FROM_END_ON_FAILURE", "true")
+			} else {
+				t.Setenv("OTR_RESUME_FROM_END_ON_FAILURE", "false")
+			}
+			require.NoError(t, config.ParseEnv())
 
 			redisServer, err := miniredis.Run()
 			if err != nil {


### PR DESCRIPTION
## Problem

When oplogtoredis (re)starts tailing, `getStartTime` reads the last-processed timestamp from Redis so it can resume from where it left off. Previously, if that Redis read **failed** (e.g. Redis unreachable), the code fell back to *"start from the end of the oplog"* — silently skipping every oplog entry written since the last processed position, dropping publications.

A failure to *read* the timestamp is different from the timestamp simply *not existing*. If we can't read from Redis, we can't write to it either, so the correct response is to retry rather than skip ahead.

## Root cause

In `getStartTime` (`lib/oplog/tail.go`):

1. **Shadowing bug** — the retry loop used `ts, tsTime, redisErr :=`, creating a new `redisErr` scoped to the loop body and leaving the outer `redisErr` always `nil`. This made the post-loop error handler dead code.
2. **Wrong fallback on read failure** — after retries were exhausted, the function fell through to the end-of-oplog timestamp and returned a `nil` error (the data-loss path above).
3. **Caller ignored the error** — `tailOnce` only logged the start-time error and then tailed from whatever timestamp was returned.

## Changes

- Fix the shadowing so a persistent read failure is visible after the loop.
- On a genuine read failure (non-nil and not `redis.Nil`), return the error instead of falling back to the end of the oplog. The `redis.Nil` (no resume point yet) and "too old" cases still fall back as before.
- `tailOnce` now aborts on a start-time error, so the `Tail` loop waits and restarts, re-reading Redis. Combined with the existing in-loop retries, oplogtoredis keeps retrying until Redis is readable rather than skipping ahead.
- Add a unit test for a persistent Redis read failure, asserting the end-of-oplog fallback is **not** used in that case.

## Escape hatch

To guard against an unanticipated situation where this retry behavior blocks startup indefinitely, there's an opt-in flag: `OTR_RESUME_FROM_END_ON_FAILURE` (default `false`). When set to `true`, a persistent Redis read failure falls back to starting from the end of the oplog (the pre-retry behavior) instead of aborting — at the cost of potentially skipping oplog entries.

This is not yet exposed in the Helm chart (which lives in a separate repo). If you need to flip it on a running deployment without a chart change, you can set it directly via kubectl as a **non-durable** override:

```bash
kubectl set env deployment/oplogtoredis OTR_RESUME_FROM_END_ON_FAILURE=true
```

To remove the override:

```bash
kubectl set env deployment/oplogtoredis OTR_RESUME_FROM_END_ON_FAILURE-
```

Note this is a live patch to the Deployment's pod template and will be **reverted on the next `helm upgrade` / ArgoCD sync**. For a durable setting, wire the env var into the chart's values.

## Testing

- `go test ./lib/...` passes (including the new `TestGetStartTime` case).
- `go build ./...` and `go vet ./lib/oplog/` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

