### PR TITLE
Oplog tail: warn on premature stop, error only on repeated failures

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 buildGoModule {
   pname = "oplogtoredis";
-  version = "3.9.1";
+  version = "3.9.2";
   src = builtins.path { path = ./.; };
 
   postInstall = ''

--- a/lib/oplog/tail.go
+++ b/lib/oplog/tail.go
@@ -53,6 +53,21 @@ type cursorResultStatus struct {
 
 const requeryDuration = time.Second
 
+// maxConsecutivePrematureStops is the number of times oplog tailing can stop
+// prematurely in a row before we escalate the log from a warning to an error.
+// A single premature stop is usually a transient blip (e.g. a brief Mongo
+// connection hiccup) that we recover from on the next retry, so it shouldn't
+// page anyone. Repeated back-to-back failures indicate a persistent problem
+// worth surfacing as an error.
+const maxConsecutivePrematureStops = 5
+
+// minSuccessfulTailDuration is how long a single tailing attempt must run
+// before we consider it to have made progress. An attempt that lasts at least
+// this long before stopping resets the consecutive-failure streak, so that
+// occasional premature stops during otherwise-healthy operation don't
+// accumulate toward the error threshold.
+const minSuccessfulTailDuration = time.Minute
+
 var (
 	// Deprecated: use metricOplogEntriesBySize instead
 	metricOplogEntriesReceived = promauto.NewCounterVec(prometheus.CounterOpts{
@@ -143,8 +158,10 @@ func (tailer *Tailer) Tail(out []PublisherChannels, stop <-chan bool, readOrdina
 		childStopC <- true
 	}()
 
+	consecutivePrematureStops := 0
 	for {
 		log.Log.Info("Starting oplog tailing")
+		tailStart := time.Now()
 		tailer.tailOnce(out, childStopC, readOrdinal, readParallelism)
 		log.Log.Info("Oplog tailing ended")
 
@@ -152,9 +169,41 @@ func (tailer *Tailer) Tail(out []PublisherChannels, stop <-chan bool, readOrdina
 			return
 		}
 
-		log.Log.Errorw("Oplog tailing stopped prematurely. Waiting a second an then retrying.")
+		// Track how many times tailing has stopped prematurely in a row. An
+		// attempt that ran long enough to be considered healthy resets the
+		// streak so that an isolated premature stop during normal operation
+		// doesn't count toward the error threshold.
+		consecutivePrematureStops = nextPrematureStopStreak(consecutivePrematureStops, time.Since(tailStart))
+
+		// A single premature stop is usually transient and recoverable, so log
+		// it as a warning. Only escalate to an error once we've failed
+		// repeatedly in a row, which indicates a persistent problem.
+		if prematureStopIsError(consecutivePrematureStops) {
+			log.Log.Errorw("Oplog tailing repeatedly stopped prematurely. Waiting a second and then retrying.",
+				"consecutivePrematureStops", consecutivePrematureStops)
+		} else {
+			log.Log.Warnw("Oplog tailing stopped prematurely. Waiting a second and then retrying.",
+				"consecutivePrematureStops", consecutivePrematureStops)
+		}
 		time.Sleep(requeryDuration)
 	}
+}
+
+// nextPrematureStopStreak returns the updated count of consecutive premature
+// tailing stops given the duration the just-finished attempt ran for. If the
+// attempt ran long enough to be considered healthy, the streak resets before
+// counting this stop.
+func nextPrematureStopStreak(streak int, ranFor time.Duration) int {
+	if ranFor >= minSuccessfulTailDuration {
+		streak = 0
+	}
+	return streak + 1
+}
+
+// prematureStopIsError reports whether a streak of consecutive premature stops
+// is large enough to be logged as an error rather than a warning.
+func prematureStopIsError(streak int) bool {
+	return streak >= maxConsecutivePrematureStops
 }
 
 // this accepts an array of PublisherChannels instances whose size is equal to the degree of write-parallelism.

--- a/lib/oplog/tail_test.go
+++ b/lib/oplog/tail_test.go
@@ -409,3 +409,27 @@ func TestParseNamespace(t *testing.T) {
 		})
 	}
 }
+
+func TestPrematureStopEscalation(t *testing.T) {
+	// A run that lasted at least minSuccessfulTailDuration resets the streak,
+	// so an isolated premature stop after healthy operation stays a warning.
+	require.Equal(t, 1, nextPrematureStopStreak(4, minSuccessfulTailDuration))
+	require.False(t, prematureStopIsError(nextPrematureStopStreak(4, minSuccessfulTailDuration)))
+
+	// A run shorter than minSuccessfulTailDuration counts toward the streak.
+	require.Equal(t, 5, nextPrematureStopStreak(4, minSuccessfulTailDuration-time.Millisecond))
+
+	// Repeated rapid failures eventually escalate to an error.
+	streak := 0
+	for i := 1; i < maxConsecutivePrematureStops; i++ {
+		streak = nextPrematureStopStreak(streak, 0)
+		require.Falsef(t, prematureStopIsError(streak), "streak %d should be a warning", streak)
+	}
+	streak = nextPrematureStopStreak(streak, 0)
+	require.Equal(t, maxConsecutivePrematureStops, streak)
+	require.True(t, prematureStopIsError(streak), "streak should escalate to error at the threshold")
+
+	// Once a healthy run occurs, the streak resets back below the threshold.
+	streak = nextPrematureStopStreak(streak, minSuccessfulTailDuration)
+	require.False(t, prematureStopIsError(streak))
+}


### PR DESCRIPTION
## Summary

The `Oplog tailing stopped prematurely` message was logged at **error** level on every retry. Because the Sentry core in `lib/log` only captures error-level logs (warnings become breadcrumbs), each transient premature stop created a Sentry issue/alert — even though a single stop is normal and self-recovering.

This changes it to **warn**, and only **error** if it repeatedly fails.

## Changes

- **Warn** on each premature stop (no Sentry alert) — the common, recoverable case.
- **Error** only after `maxConsecutivePrematureStops` (5) failures in a row — a persistent problem worth alerting on.
- The streak **resets** whenever an attempt ran at least `minSuccessfulTailDuration` (1 min) before stopping, so occasional blips during healthy operation don't slowly accumulate toward the error threshold. Only rapid, repeated failures escalate.
- Both log lines now include a `consecutivePrematureStops` field, and the message typo ("an then" → "and then") is fixed.
- Decision logic extracted into pure helpers (`nextPrematureStopStreak`, `prematureStopIsError`) so it's unit-testable without a live Mongo connection.

Note: the tailer still retries forever — this only changes log severity, not the retry/give-up behavior.

## Testing

- Added `TestPrematureStopEscalation` covering warn-on-isolated-stop, streak accumulation, escalation at threshold, and reset after a healthy run.
- `go test ./lib/oplog/` passes; `go build ./...` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)