### PR TITLE
metrics: add otr_oplog_entries_by_collection metric

### DIFF
--- a/lib/oplog/tail.go
+++ b/lib/oplog/tail.go
@@ -134,6 +134,13 @@ var (
 		Name:      "tail_failed_to_start",
 		Help:      "Number of times oplog tailing failed to start, partitioned by reason",
 	}, []string{"reason"})
+
+	metricOplogEntriesByCollection = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "otr",
+		Subsystem: "oplog",
+		Name:      "entries_by_collection",
+		Help:      "Oplog entries received, partitioned by database and collection",
+	}, []string{"database", "collection"})
 )
 
 func init() {
@@ -452,10 +459,12 @@ func (tailer *Tailer) processEntry(rawData bson.Raw, readOrdinal int) (timestamp
 
 	status := "ignored"
 	database := "(no database)"
+	collection := "(no collection)"
 	messageLen := float64(len(rawData))
 
 	if len(entries) > 0 {
 		database = entries[0].Database
+		collection = entries[0].Collection
 	}
 
 	sendMetricsData = func() {
@@ -466,6 +475,7 @@ func (tailer *Tailer) processEntry(rawData bson.Raw, readOrdinal int) (timestamp
 		metricOplogEntriesBySize.WithLabelValues(database, status).Observe(messageLen)
 		metricMaxOplogEntryByMinute.Report(messageLen, database, status)
 		metricLastReceivedStaleness.WithLabelValues(strconv.Itoa(readOrdinal)).Set(float64(time.Since(time.Unix(int64(timestamp.T), 0))))
+		metricOplogEntriesByCollection.WithLabelValues(database, collection).Inc()
 	}
 
 	type errEntry struct {


### PR DESCRIPTION

## Summary

Adds a new `otr_oplog_entries_by_collection` to track entries by collection and database. 

## Level of Impact

Please select exactly one option. To change the level of impact, first unselect the current level of impact and then select the new level of impact.

- [ ] 1 - High
- [ ] 2 - Medium
- [ ] 3 - Low
- [X] 4 - No-op

## Impact Analysis
Metric change only

## Test Plan
N/A (metric is present)

## Checklist

- [X] Test Plan Fully Executed
- [X] Does not require security review or security review complete
