### PR TITLE
oplogtoredis: Seed Deny List with Admin Database

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 
 buildGoModule {
   pname = "oplogtoredis";
-  version = "3.9.3";
+  version = "3.9.4";
   src = builtins.path { path = ./.; };
 
   postInstall = ''

--- a/integration-tests/acceptance/denylist_http_test.go
+++ b/integration-tests/acceptance/denylist_http_test.go
@@ -2,53 +2,59 @@ package main
 
 import (
 	"os"
-	"reflect"
 	"testing"
 
 	"github.com/tulip/oplogtoredis/integration-tests/helpers"
+	"github.com/tulip/oplogtoredis/lib/denylist"
 )
 
 // Test the /denylist HTTP operations
 func TestDenyList(t *testing.T) {
 	baseURL := os.Getenv("OTR_URL")
 
-	// GET empty list of rules
+	// GET list of rules: should contain only the seeded entries
 	data := helpers.DoRequest("GET", baseURL, "/denylist", t, 200)
-	if !reflect.DeepEqual(data, []interface{}{}) {
-		t.Fatalf("Expected empty list from blank GET, but got %#v", data)
-	}
+	helpers.AssertDenylistContains(t, data, denylist.SeedEntries)
+
 	// PUT new rule
 	helpers.DoRequest("PUT", baseURL, "/denylist/abc", t, 201)
 	// GET list with new rule in it
 	data = helpers.DoRequest("GET", baseURL, "/denylist", t, 200)
-	if !reflect.DeepEqual(data, []interface{}{"abc"}) {
-		t.Fatalf("Expected singleton from GET, but got %#v", data)
-	}
+	helpers.AssertDenylistContains(t, data, append(append([]string{}, denylist.SeedEntries...), "abc"))
 	// GET existing rule
 	data = helpers.DoRequest("GET", baseURL, "/denylist/abc", t, 200)
-	if !reflect.DeepEqual(data, "abc") {
+	if data != "abc" {
 		t.Fatalf("Expected matched body from GET, but got %#v", data)
 	}
 	// PUT second rule
 	helpers.DoRequest("PUT", baseURL, "/denylist/def", t, 201)
 	// GET second rule
 	data = helpers.DoRequest("GET", baseURL, "/denylist/def", t, 200)
-	if !reflect.DeepEqual(data, "def") {
+	if data != "def" {
 		t.Fatalf("Expected matched body from GET, but got %#v", data)
 	}
-	// GET list with both rules
+	// GET list with both rules plus the seeded entries
 	data = helpers.DoRequest("GET", baseURL, "/denylist", t, 200)
-	// check both permutations, in case the server reordered them
-	if !reflect.DeepEqual(data, []interface{}{"abc", "def"}) && !reflect.DeepEqual(data, []interface{}{"def", "abc"}) {
-		t.Fatalf("Expected doubleton from GET, but got %#v", data)
-	}
+	helpers.AssertDenylistContains(t, data, append(append([]string{}, denylist.SeedEntries...), "abc", "def"))
 	// DELETE first rule
 	helpers.DoRequest("DELETE", baseURL, "/denylist/abc", t, 204)
 	// GET first rule
 	helpers.DoRequest("GET", baseURL, "/denylist/abc", t, 404)
-	// GET list with only second rule
+	// GET list with only second rule plus the seeded entries
 	data = helpers.DoRequest("GET", baseURL, "/denylist", t, 200)
-	if !reflect.DeepEqual(data, []interface{}{"def"}) {
-		t.Fatalf("Expected singleton from GET, but got %#V", data)
+	helpers.AssertDenylistContains(t, data, append(append([]string{}, denylist.SeedEntries...), "def"))
+}
+
+// The seeded entries should be present on the denylist without any manual
+// PUT, and should actually filter (a seeded DB is reported as denied).
+func TestDenyListSeeded(t *testing.T) {
+	baseURL := os.Getenv("OTR_URL")
+
+	for _, entry := range denylist.SeedEntries {
+		// GET the seeded rule directly; it should already exist (200)
+		data := helpers.DoRequest("GET", baseURL, "/denylist/"+entry, t, 200)
+		if data != entry {
+			t.Fatalf("Expected seeded entry %q from GET, but got %#v", entry, data)
+		}
 	}
 }

--- a/integration-tests/fault-injection/denylist_persistence_test.go
+++ b/integration-tests/fault-injection/denylist_persistence_test.go
@@ -2,12 +2,12 @@ package main
 
 import (
 	"fmt"
-	"reflect"
 	"testing"
 	"time"
 
 	"github.com/tulip/oplogtoredis/integration-tests/fault-injection/harness"
 	"github.com/tulip/oplogtoredis/integration-tests/helpers"
+	"github.com/tulip/oplogtoredis/lib/denylist"
 )
 
 // This test restarts oplogtoredis after adding denylist entries.
@@ -40,12 +40,10 @@ func TestDenylistPersistence(t *testing.T) {
 	helpers.DoRequest("PUT", baseURL, "/denylist/abc", t, 201)
 	// PUT second rule
 	helpers.DoRequest("PUT", baseURL, "/denylist/def", t, 201)
-	// GET list with both rules
+	// GET list with both rules plus the seeded entries
 	data := helpers.DoRequest("GET", baseURL, "/denylist", t, 200)
-	// check both permutations, in case the server reordered them
-	if !reflect.DeepEqual(data, []interface{}{"abc", "def"}) && !reflect.DeepEqual(data, []interface{}{"def", "abc"}) {
-		t.Fatalf("Expected doubleton from GET, but got %#v", data)
-	}
+	expectedDenylist := append(append([]string{}, denylist.SeedEntries...), "abc", "def")
+	helpers.AssertDenylistContains(t, data, expectedDenylist)
 
 	otr.Stop()
 	time.Sleep(3 * time.Second)
@@ -53,22 +51,15 @@ func TestDenylistPersistence(t *testing.T) {
 
 	time.Sleep(3 * time.Second)
 
-	// denylist should have persisted across the restart
-
-	// GET list with both rules
+	// GET list with both rules plus the seeded entries
 	data = helpers.DoRequest("GET", baseURL, "/denylist", t, 200)
-	// check both permutations, in case the server reordered them
-	if !reflect.DeepEqual(data, []interface{}{"abc", "def"}) && !reflect.DeepEqual(data, []interface{}{"def", "abc"}) {
-		t.Fatalf("Expected doubleton from GET, but got %#v", data)
-	}
+	helpers.AssertDenylistContains(t, data, append(append([]string{}, denylist.SeedEntries...), "abc", "def"))
 
 	// denylist should still be modifiable
 
 	// DELETE first rule
 	helpers.DoRequest("DELETE", baseURL, "/denylist/abc", t, 204)
-	// GET list with only second rule
+	// GET list with only second rule plus the seeded entries
 	data = helpers.DoRequest("GET", baseURL, "/denylist", t, 200)
-	if !reflect.DeepEqual(data, []interface{}{"def"}) {
-		t.Fatalf("Expected singleton from GET, but got %#V", data)
-	}
+	helpers.AssertDenylistContains(t, data, append(append([]string{}, denylist.SeedEntries...), "def"))
 }

--- a/integration-tests/fault-injection/harness/redis.go
+++ b/integration-tests/fault-injection/harness/redis.go
@@ -33,7 +33,7 @@ func StartRedisServer() *RedisServer {
 // This function does not return until the server is up and ready to accept
 // connections.
 func (server *RedisServer) Start() {
-	log.Print("Startinf up Redis server")
+	log.Print("Starting up Redis server")
 	server.node = exec.Command("redis-server", "--loglevel", "debug") // #nosec
 
 	server.node.Stdout = makeLogStreamer("redis", "stdout")

--- a/integration-tests/helpers/denylist.go
+++ b/integration-tests/helpers/denylist.go
@@ -1,0 +1,36 @@
+package helpers
+
+import (
+	"sort"
+	"testing"
+)
+
+func AssertDenylistContains(t *testing.T, data interface{}, expected []string) {
+	t.Helper()
+
+	raw, ok := data.([]interface{})
+	if !ok {
+		t.Fatalf("Expected a list from GET /denylist, but got %#v", data)
+	}
+
+	got := make([]string, 0, len(raw))
+	for _, entry := range raw {
+		s, ok := entry.(string)
+		if !ok {
+			t.Fatalf("Expected string entries in /denylist, but got %#v", entry)
+		}
+		got = append(got, s)
+	}
+
+	sort.Strings(got)
+	sort.Strings(expected)
+
+	if len(got) != len(expected) {
+		t.Fatalf("Expected denylist %#v, but got %#v", expected, got)
+	}
+	for i := range expected {
+		if got[i] != expected[i] {
+			t.Fatalf("Expected denylist %#v, but got %#v", expected, got)
+		}
+	}
+}

--- a/lib/denylist/seed.go
+++ b/lib/denylist/seed.go
@@ -1,0 +1,29 @@
+package denylist
+
+import (
+	"sync"
+
+	"github.com/tulip/oplogtoredis/lib/log"
+)
+
+var SeedEntries = []string{
+	"admin",
+}
+
+func Seed(denylist *sync.Map, syncer *Syncer) error {
+	for _, id := range SeedEntries {
+		if _, exists := denylist.Load(id); exists {
+			continue
+		}
+
+		denylist.Store(id, true)
+		metricFilterEnabled.WithLabelValues(id).Set(1)
+		log.Log.Infow("Denylist seed: Added entry", "id", id)
+
+		if err := syncer.StoreDenylistEntry(denylist, id); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/lib/denylist/seed.go
+++ b/lib/denylist/seed.go
@@ -11,16 +11,16 @@ var SeedEntries = []string{
 }
 
 func Seed(denylist *sync.Map, syncer *Syncer) error {
-	for _, id := range SeedEntries {
-		if _, exists := denylist.Load(id); exists {
+	for _, entry := range SeedEntries {
+		if _, exists := denylist.Load(entry); exists {
 			continue
 		}
 
-		denylist.Store(id, true)
-		metricFilterEnabled.WithLabelValues(id).Set(1)
-		log.Log.Infow("Denylist seed: Added entry", "id", id)
+		denylist.Store(entry, true)
+		metricFilterEnabled.WithLabelValues(entry).Set(1)
+		log.Log.Infow("Denylist seed: Added entry", "id", entry)
 
-		if err := syncer.StoreDenylistEntry(denylist, id); err != nil {
+		if err := syncer.StoreDenylistEntry(denylist, entry); err != nil {
 			return err
 		}
 	}

--- a/lib/denylist/seed_test.go
+++ b/lib/denylist/seed_test.go
@@ -1,0 +1,82 @@
+package denylist
+
+import (
+	"sync"
+	"testing"
+)
+
+// mapKeys returns the keys currently stored in a sync.Map as a set.
+func mapKeys(m *sync.Map) map[string]bool {
+	keys := map[string]bool{}
+	m.Range(func(key, _ interface{}) bool {
+		keys[key.(string)] = true
+		return true
+	})
+	return keys
+}
+
+// nonPersistentSyncer returns a Syncer that does not touch a database, so Seed
+// can be tested without Postgres.
+func nonPersistentSyncer(t *testing.T) *Syncer {
+	t.Helper()
+	syncer, err := NewSyncer("")
+	if err != nil {
+		t.Fatalf("NewSyncer returned an unexpected error: %v", err)
+	}
+	return syncer
+}
+
+func TestSeedPopulatesEmptyDenylist(t *testing.T) {
+	denylist := &sync.Map{}
+
+	if err := Seed(denylist, nonPersistentSyncer(t)); err != nil {
+		t.Fatalf("Seed returned an unexpected error: %v", err)
+	}
+
+	keys := mapKeys(denylist)
+	for _, entry := range SeedEntries {
+		if !keys[entry] {
+			t.Errorf("Expected denylist to contain seeded entry %q, but it did not", entry)
+		}
+	}
+	if len(keys) != len(SeedEntries) {
+		t.Errorf("Expected denylist to contain exactly %d seeded entries, but got %d: %v",
+			len(SeedEntries), len(keys), keys)
+	}
+}
+
+func TestSeedIsIdempotent(t *testing.T) {
+	denylist := &sync.Map{}
+	syncer := nonPersistentSyncer(t)
+
+	if err := Seed(denylist, syncer); err != nil {
+		t.Fatalf("first Seed returned an unexpected error: %v", err)
+	}
+	if err := Seed(denylist, syncer); err != nil {
+		t.Fatalf("second Seed returned an unexpected error: %v", err)
+	}
+
+	keys := mapKeys(denylist)
+	if len(keys) != len(SeedEntries) {
+		t.Errorf("Expected %d entries after seeding twice, but got %d: %v",
+			len(SeedEntries), len(keys), keys)
+	}
+}
+
+func TestSeedPreservesExistingEntries(t *testing.T) {
+	denylist := &sync.Map{}
+	denylist.Store("existing", true)
+
+	if err := Seed(denylist, nonPersistentSyncer(t)); err != nil {
+		t.Fatalf("Seed returned an unexpected error: %v", err)
+	}
+
+	if _, ok := denylist.Load("existing"); !ok {
+		t.Error("Expected pre-existing entry \"existing\" to be preserved after seeding")
+	}
+	for _, entry := range SeedEntries {
+		if _, ok := denylist.Load(entry); !ok {
+			t.Errorf("Expected seeded entry %q to be present after seeding", entry)
+		}
+	}
+}

--- a/lib/log/main.go
+++ b/lib/log/main.go
@@ -68,7 +68,8 @@ func init() {
 func sentryInit(log *zap.Logger) *zap.Logger {
 	errConfig := config.ParseEnv()
 	if errConfig != nil {
-		panic("Error parsing environment variables: " + errConfig.Error())
+		// main() will surface an error there if env is invalid
+		return log
 	}
 	if !config.SentryEnabled() {
 		return log

--- a/main.go
+++ b/main.go
@@ -58,9 +58,13 @@ func main() {
 	if err != nil {
 		panic("Error setting up persistent denylist: " + err.Error())
 	}
-	denylist, err := syncer.LoadDenylist()
+	denylistMap, err := syncer.LoadDenylist()
 	if err != nil {
 		panic("Error loading persistent denylist: " + err.Error())
+	}
+	err = denylist.Seed(denylistMap, syncer)
+	if err != nil {
+		panic("Error seeding denylist: " + err.Error())
 	}
 
 	// this loop starts one writer shard on each pass. Repeat it a number of times equal to the write parallelism level.
@@ -170,7 +174,7 @@ func main() {
 				// it doesn't really matter which one since this isn't a meaningful amount of load, so just take the first one
 				RedisPrefix: config.RedisMetadataPrefix(),
 				MaxCatchUp:  config.MaxCatchUp(),
-				Denylist:    denylist,
+				Denylist:    denylistMap,
 			}
 			// pass all intake channels to the tailer, which will route messages accordingly
 			tailer.Tail(aggregatedRedisPubs, stopOplogTail, i, readParallelism)
@@ -183,7 +187,7 @@ func main() {
 	var shuttingDown bool
 
 	// Start one more goroutine for the HTTP server
-	httpServer := makeHTTPServer(aggregatedRedisClients, aggregatedMongoSessions, denylist, syncer)
+	httpServer := makeHTTPServer(aggregatedRedisClients, aggregatedMongoSessions, denylistMap, syncer)
 	go func() {
 		httpErr := httpServer.ListenAndServe()
 		if shuttingDown {


### PR DESCRIPTION
Add functionality for seeding the denylist with values, and for now seed it with just the internal mongo "admin" database so that its operations are not tailed.

If a seeded denylist entry is deleted via the API, it will re-enter the deny list on the next restart.